### PR TITLE
Remove not supported on a CopyOnWriteArrayList.

### DIFF
--- a/agent-parent/agent/src/main/java/org/glowroot/agent/model/Transaction.java
+++ b/agent-parent/agent/src/main/java/org/glowroot/agent/model/Transaction.java
@@ -580,7 +580,7 @@ public class Transaction {
                 }
             }
             auxThreadContext.detach();
-            i.remove();
+//            i.remove();
         }
         if (immedateTraceStoreRunnable != null) {
             immedateTraceStoreRunnable.cancel();


### PR DESCRIPTION
`auxThreadContexts` is a `Lists.newCopyOnWriteArrayList();` so remove is not supported, seeing errors when running the agent.

```
java.lang.UnsupportedOperationException
at java.util.concurrent.CopyOnWriteArrayList$COWIterator.remove (CopyOnWriteArrayList.java:1176)
at org.glowroot.agent.model.Transaction.end (Transaction.java:583)
...
```