### PR TITLE
Add support to connect to Cassandra instance which requires authentication

### DIFF
--- a/central/src/main/webapp/META-INF/glowroot-central.properties
+++ b/central/src/main/webapp/META-INF/glowroot-central.properties
@@ -1,6 +1,13 @@
 # default is cassandra.contactPoints=127.0.0.1
 cassandra.contactPoints=
 
+# Authentication type for cassandra connection (supported values - plain-text)
+cassandra.authType=
+# Username to use to connect to cassandra, when authType is plain-text
+#cassandra.username=
+# Password to use to connect to cassandra, when authType is plain-text
+#cassandra.password=
+
 # default is cassandra.keyspace=glowroot
 cassandra.keyspace=
 


### PR DESCRIPTION
The central collector currently doesn't seem to have the ability to connect to a Cassandra instance which enforces authentication. The commit here introduces an enhancement which allows the user to configure `cassandra.authType` property to specify the type of authentication to use while connecting to Cassandra nodes. 

Right now, in this commit, only `plain-text` authType support is added. When this authType is configured, the user can additional provide `cassandra.username` and `cassandra.password` property values, which will then be used by the plain text auth provider to connect to Cassandra.

In future, the authType property could allow other different types and additional expect other different properties to setup the auth provider.

P.S: I'm still getting used to the code base and will continue digging more into it to see where/how to create tests for changes like these. Right now, this commit doesn't have automated tests, but the change has been manually tested locally.
