### PR TITLE
Fix instrumentation import JSON from UI to pass methoAnnotation and classAnnotation

### DIFF
--- a/ui/src/main/java/org/glowroot/ui/InstrumentationConfigJsonService.java
+++ b/ui/src/main/java/org/glowroot/ui/InstrumentationConfigJsonService.java
@@ -348,8 +348,10 @@ class InstrumentationConfigJsonService {
         private InstrumentationConfig convert() {
             InstrumentationConfig.Builder builder = InstrumentationConfig.newBuilder()
                     .setClassName(className())
+                    .setClassAnnotation(classAnnotation())
                     .setMethodDeclaringClassName(methodDeclaringClassName())
                     .setMethodName(methodName())
+                    .setMethodAnnotation(methodAnnotation())
                     .addAllMethodParameterType(methodParameterTypes())
                     .setMethodReturnType(methodReturnType())
                     .addAllMethodModifier(methodModifiers())


### PR DESCRIPTION
The commit here fixes an issue in the web UI feature of "Import" instrumentation config JSON, where it currently ignores the `methodAnnotation` and `classAnnotation` attributes that may have been specified in the config JSON. 
