### PR TITLE
Fix a bug which would create an incorrect central jar

### DIFF
--- a/central/pom.xml
+++ b/central/pom.xml
@@ -223,6 +223,7 @@
               <goal>jar</goal>
             </goals>
             <configuration>
+              <forceCreation>true</forceCreation>
               <archive>
                 <manifest>
                   <addClasspath>true</addClasspath>


### PR DESCRIPTION
While building glowroot, I sometimes randomly run into issue where the glowroot central jar that gets created, via the central/pom.xml maven-jar-plugin configurations, cannot be used to run it as a standalone application through:

```
unzip target/glowroot*-dist.zip -d foo
cd foo/glowroot-central
java -jar glowroot-central.jar
```


That commands runs into an error stating that the jar's manifest is missing the `Main-Class` attribute. Of course, that is a sign that the jar itself is missing a bunch of other stuff.

It's not always the case though, sometimes it just works. So I read up the maven-jar-plugin documentation here [1] which has some relevant information about the `forceCreation` attribute for this plugin's `jar` goal. It looks like we are running into this issue with the maven-jar-plugin, where it considers that nothing has changed in that jar and doesn't update it with the Manifest details. The central/pom.xml already has a hint which seems to indicate that similar issues have been run into with this pom previously.

The commit in this PR, adds the `forceCreation` configuration to the maven-jar-plugin to make sure it always creates the jar correctly with the manifest details specified in that configuration. With this change, I haven't yet run into the issue with the jar missing the Manifest details and such.

[1] https://maven.apache.org/plugins/maven-jar-plugin/jar-mojo.html