### PR TITLE
Add support for superTypeRestriction in instrumentation config JSON

### DIFF
--- a/agent/core/src/main/java/org/glowroot/agent/config/InstrumentationConfig.java
+++ b/agent/core/src/main/java/org/glowroot/agent/config/InstrumentationConfig.java
@@ -58,6 +58,12 @@ public abstract class InstrumentationConfig {
         return "";
     }
 
+    @Value.Default
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String superTypeRestriction() {
+        return "";
+    }
+
     // pointcuts with methodDeclaringClassName are no longer supported in 0.9.16, but included here
     // to help with transitioning of old instrumentation config
     @Deprecated
@@ -237,6 +243,7 @@ public abstract class InstrumentationConfig {
                         .setClassName(className())
                         .setClassAnnotation(classAnnotation())
                         .setSubTypeRestriction(subTypeRestriction())
+                        .setSuperTypeRestriction(superTypeRestriction())
                         // pointcuts with methodDeclaringClassName are no longer supported in
                         // 0.9.16, but included here to help with transitioning of old
                         // instrumentation config
@@ -277,6 +284,7 @@ public abstract class InstrumentationConfig {
                 .className(config.getClassName())
                 .classAnnotation(config.getClassAnnotation())
                 .subTypeRestriction(config.getSubTypeRestriction())
+                .superTypeRestriction(config.getSuperTypeRestriction())
                 // pointcuts with methodDeclaringClassName are no longer supported in 0.9.16, but
                 // included here to help with transitioning of old instrumentation config
                 .methodDeclaringClassName(config.getMethodDeclaringClassName())

--- a/agent/core/src/main/java/org/glowroot/agent/weaving/AdviceBuilder.java
+++ b/agent/core/src/main/java/org/glowroot/agent/weaving/AdviceBuilder.java
@@ -143,6 +143,7 @@ class AdviceBuilder {
         builder.pointcutClassNamePattern(buildPattern(pointcut.className()));
         builder.pointcutClassAnnotationPattern(buildPattern(pointcut.classAnnotation()));
         builder.pointcutSubTypeRestrictionPattern(buildPattern(pointcut.subTypeRestriction()));
+        builder.pointcutSuperTypeRestrictionPattern(buildPattern(pointcut.superTypeRestriction()));
         builder.pointcutMethodNamePattern(buildPattern(pointcut.methodName()));
         builder.pointcutMethodAnnotationPattern(buildPattern(pointcut.methodAnnotation()));
         builder.pointcutMethodParameterTypes(buildPatterns(pointcut.methodParameterTypes()));

--- a/agent/core/src/main/java/org/glowroot/agent/weaving/AdviceGenerator.java
+++ b/agent/core/src/main/java/org/glowroot/agent/weaving/AdviceGenerator.java
@@ -155,6 +155,7 @@ class AdviceGenerator {
         annotationVisitor.visit("className", config.className());
         annotationVisitor.visit("classAnnotation", config.classAnnotation());
         annotationVisitor.visit("subTypeRestriction", config.subTypeRestriction());
+        annotationVisitor.visit("superTypeRestriction", config.superTypeRestriction());
         annotationVisitor.visit("methodName", config.methodName());
         annotationVisitor.visit("methodAnnotation", config.methodAnnotation());
         AnnotationVisitor arrayAnnotationVisitor =

--- a/ui/app/scripts/controllers/config/instrumentation-list.js
+++ b/ui/app/scripts/controllers/config/instrumentation-list.js
@@ -162,6 +162,7 @@ glowroot.controller('ConfigInstrumentationListCtrl', [
         var base = {
           classAnnotation: '',
           subTypeRestriction: '',
+          superTypeRestriction: '',
           methodAnnotation: '',
           methodReturnType: '',
           nestingGroup: '',

--- a/ui/app/scripts/controllers/config/instrumentation.js
+++ b/ui/app/scripts/controllers/config/instrumentation.js
@@ -113,6 +113,7 @@ glowroot.controller('ConfigInstrumentationCtrl', [
                 // (see instrumentation-list.js)
                 classAnnotation: '',
                 subTypeRestriction: '',
+                superTypeRestriction: '',
                 methodAnnotation: '',
                 nestingGroup: '',
                 order: 0,

--- a/ui/app/scripts/services/instrumentation-export.js
+++ b/ui/app/scripts/services/instrumentation-export.js
@@ -26,6 +26,9 @@ glowroot.factory('instrumentationExport', [
       if (!config.subTypeRestriction) {
         delete config.subTypeRestriction;
       }
+      if (!config.superTypeRestriction) {
+        delete config.superTypeRestriction;
+      }
       if (!config.methodAnnotation) {
         delete config.methodAnnotation;
       }

--- a/ui/src/main/java/org/glowroot/ui/InstrumentationConfigJsonService.java
+++ b/ui/src/main/java/org/glowroot/ui/InstrumentationConfigJsonService.java
@@ -324,6 +324,7 @@ class InstrumentationConfigJsonService {
         abstract String className();
         abstract String classAnnotation();
         abstract String subTypeRestriction();
+        abstract String superTypeRestriction();
         // pointcuts with methodDeclaringClassName are no longer supported in 0.9.16, but
         // included here to help with transitioning of old instrumentation config
         //
@@ -358,6 +359,7 @@ class InstrumentationConfigJsonService {
                     .setClassName(className())
                     .setClassAnnotation(classAnnotation())
                     .setSubTypeRestriction(subTypeRestriction())
+                    .setSuperTypeRestriction(superTypeRestriction())
                     // pointcuts with methodDeclaringClassName are no longer supported in 0.9.16,
                     // but included here to help with transitioning of old instrumentation config
                     //
@@ -402,6 +404,7 @@ class InstrumentationConfigJsonService {
                             .className(config.getClassName())
                             .classAnnotation(config.getClassAnnotation())
                             .subTypeRestriction(config.getSubTypeRestriction())
+                            .superTypeRestriction(config.getSuperTypeRestriction())
                             // pointcuts with methodDeclaringClassName are no longer supported in
                             // 0.9.16, but included here to help with transitioning of old
                             // instrumentation config

--- a/wire-api/src/main/proto/AgentConfig.proto
+++ b/wire-api/src/main/proto/AgentConfig.proto
@@ -99,6 +99,7 @@ message AgentConfig {
     string class_name = 1;
     string class_annotation = 2;
     string sub_type_restriction = 24;
+    string super_type_restriction = 25;
     string method_declaring_class_name = 3; // deprecated in 0.9.16, still supported here for
                                             // glowroot central 0.9.16 or newer running agent 0.9.15
                                             // or older


### PR DESCRIPTION
The commit here adds support to the instrumentation config JSON to use the `superTypeRestriction` feature that was introduced in this commit https://github.com/glowroot/glowroot/commit/e3301aa15d08fc3497da2fd5ac8ac76b2ddcf1be
