### PR TITLE
java.util.logging support & new Java HTTP Server Plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # standard environment (sudo: required) is provisioned with 7.5g memory, but has 50 minute time limit for jobs
 # container-based environment (sudo: false) is provisioned with only 4g memory, but haven't run into time limit for jobs yet
+dist: precise
 sudo: false
 language: java
 before_install:

--- a/agent/dist/pom.xml
+++ b/agent/dist/pom.xml
@@ -53,6 +53,11 @@
     </dependency>
     <dependency>
       <groupId>org.glowroot</groupId>
+      <artifactId>glowroot-agent-java-http-server-plugin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glowroot</groupId>
       <artifactId>glowroot-agent-jaxrs-plugin</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/agent/plugins/java-http-server-plugin/pom.xml
+++ b/agent/plugins/java-http-server-plugin/pom.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.glowroot</groupId>
+    <artifactId>glowroot-parent</artifactId>
+    <version>0.9.23-SNAPSHOT</version>
+    <relativePath>../../..</relativePath>
+  </parent>
+
+  <artifactId>glowroot-agent-java-http-server-plugin</artifactId>
+
+  <name>Glowroot Agent Java Http Server Plugin</name>
+  <description>Glowroot Agent Java Http Server Plugin</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.glowroot</groupId>
+      <artifactId>glowroot-agent-plugin-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <!-- guava library is shaded below so that the plugin can use the guava library that is
+        already shaded and embedded inside glowroot-agent -->
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${checker.qual.group.id}</groupId>
+      <artifactId>${checker.qual.artifact.id}</artifactId>
+      <version>${checker.qual.version}</version>
+      <!-- don't need this dependency at runtime since only annotations -->
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <!-- don't need this dependency at runtime since only annotations -->
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glowroot</groupId>
+      <artifactId>glowroot-agent-it-harness</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <!-- executor plugin is included to test async servlets -->
+      <groupId>org.glowroot</groupId>
+      <artifactId>glowroot-agent-executor-plugin</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <!-- this is just so eclipse will use Java 7 for this module, since Java 7 is needed for
+            running tests in eclipse because some tests depend on the executor plugin which targets
+            Java 7 for default-testCompile just so eclipse will use Java 7 for that module, in order
+            to run that module's own ForkJoinPool tests -->
+          <artifactId>maven-compiler-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>default-testCompile</id>
+              <configuration>
+                <source>1.7</source>
+                <target>1.7</target>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>java6or7</id>
+      <activation>
+        <jdk>[1.6,1.8)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <!-- this is needed when building with Java 6 or 7 -->
+              <argLine>-XX:MaxPermSize=128m</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>shade</id>
+      <activation>
+        <property>
+          <name>!glowroot.shade.skip</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <configuration>
+              <dependencyReducedPomLocation>
+                ${project.build.directory}/dependency-reduced-pom.xml
+              </dependencyReducedPomLocation>
+              <createSourcesJar>true</createSourcesJar>
+              <shadeSourcesContent>true</shadeSourcesContent>
+            </configuration>
+            <executions>
+              <execution>
+                <id>default</id>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <artifactSet>
+                    <includes>
+                      <include>org.glowroot.plugins:java-http-server-plugin</include>
+                    </includes>
+                  </artifactSet>
+                  <relocations>
+                    <relocation>
+                      <pattern>com.google.common</pattern>
+                      <shadedPattern>org.glowroot.agent.shaded.google.common</shadedPattern>
+                    </relocation>
+                  </relocations>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>force-java6</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>default-testCompile</id>
+                  <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/agent/plugins/java-http-server-plugin/src/main/java/org/glowroot/agent/plugin/javahttpserver/DetailCapture.java
+++ b/agent/plugins/java-http-server-plugin/src/main/java/org/glowroot/agent/plugin/javahttpserver/DetailCapture.java
@@ -69,6 +69,7 @@ class DetailCapture {
         if (headerNames == null) {
             return ImmutableMap.of();
         }
+        final ImmutableList<Pattern> maskPatterns = JavaHttpServerPluginProperties.maskRequestHeaders();
         final Map<String, Object> requestHeaders = Maps.newHashMap();
         for (final String name : headerNames) {
             if (name == null) {
@@ -77,6 +78,10 @@ class DetailCapture {
             // converted to lower case for case-insensitive matching (patterns are lower case)
             final String keyLowerCase = name.toLowerCase(Locale.ENGLISH);
             if (!matchesOneOf(keyLowerCase, capturePatterns)) {
+                continue;
+            }
+            if (matchesOneOf(keyLowerCase, maskPatterns)) {
+                requestHeaders.put(name, "****");
                 continue;
             }
             final List<String> values = headers.get(name);
@@ -113,7 +118,7 @@ class DetailCapture {
 
     private static @Nullable String getRemoteHost(@Nullable InetSocketAddress remoteAddress) {
         if (remoteAddress != null) {
-            return remoteAddress.getHostString();
+            return remoteAddress.getHostName();
         } else {
             return null;
         }

--- a/agent/plugins/java-http-server-plugin/src/main/java/org/glowroot/agent/plugin/javahttpserver/DetailCapture.java
+++ b/agent/plugins/java-http-server-plugin/src/main/java/org/glowroot/agent/plugin/javahttpserver/DetailCapture.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2014-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.javahttpserver;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+
+import org.glowroot.agent.plugin.javahttpserver.HttpHandlerAspect.Headers;
+import org.glowroot.agent.plugin.javahttpserver.HttpHandlerAspect.HttpExchange;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+// shallow copies are necessary because request may not be thread safe, which may affect ability
+// to see detail from active traces
+//
+// shallow copies are also necessary because servlet container may clear out the objects after the
+// request is complete (e.g. tomcat does this) in order to reuse them, in which case this detail
+// would need to be captured synchronously at end of request anyways (although then it could be
+// captured only if trace met threshold for storage...)
+class DetailCapture {
+
+    private DetailCapture() {}
+
+    static ImmutableMap<String, Object> captureRequestHeaders(HttpExchange exchange) {
+        final ImmutableList<Pattern> capturePatterns = JavaHttpServerPluginProperties.captureRequestHeaders();
+        if (capturePatterns.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        return captureHeaders(capturePatterns, exchange.glowroot$getRequestHeaders());
+    }
+
+    static ImmutableMap<String, Object> captureResponseHeaders(HttpExchange exchange) {
+        final ImmutableList<Pattern> capturePatterns = JavaHttpServerPluginProperties.captureResponseHeaders();
+        if (capturePatterns.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        return captureHeaders(capturePatterns, exchange.glowroot$getResponseHeaders());
+    }
+
+    private static ImmutableMap<String, Object> captureHeaders(final ImmutableList<Pattern> capturePatterns,
+            @Nullable Headers headers) {
+        if (headers == null) {
+            return ImmutableMap.of();
+        }
+        final Set<String> headerNames = headers.keySet();
+        if (headerNames == null) {
+            return ImmutableMap.of();
+        }
+        final Map<String, Object> requestHeaders = Maps.newHashMap();
+        for (final String name : headerNames) {
+            if (name == null) {
+                continue;
+            }
+            // converted to lower case for case-insensitive matching (patterns are lower case)
+            final String keyLowerCase = name.toLowerCase(Locale.ENGLISH);
+            if (!matchesOneOf(keyLowerCase, capturePatterns)) {
+                continue;
+            }
+            final List<String> values = headers.get(name);
+            if (values != null) {
+                captureHeader(name, values, requestHeaders);
+            }
+        }
+        return ImmutableMap.copyOf(requestHeaders);
+    }
+
+    static @Nullable String captureRequestRemoteAddr(HttpExchange exchange) {
+        if (JavaHttpServerPluginProperties.captureRequestRemoteAddr()) {
+            return getRemoteAddr(exchange.getRemoteAddress());
+        } else {
+            return null;
+        }
+    }
+
+    private static @Nullable String getRemoteAddr(@Nullable InetSocketAddress remoteAddress) {
+        if (remoteAddress != null && remoteAddress.getAddress() != null) {
+            return remoteAddress.getAddress().getHostAddress();
+        } else {
+            return null;
+        }
+    }
+
+    static @Nullable String captureRequestRemoteHost(HttpExchange exchange) {
+        if (JavaHttpServerPluginProperties.captureRequestRemoteHost()) {
+            return getRemoteHost(exchange.getRemoteAddress());
+        } else {
+            return null;
+        }
+    }
+
+    private static @Nullable String getRemoteHost(@Nullable InetSocketAddress remoteAddress) {
+        if (remoteAddress != null) {
+            return remoteAddress.getHostString();
+        } else {
+            return null;
+        }
+    }
+
+    private static boolean matchesOneOf(String key, List<Pattern> patterns) {
+        for (final Pattern pattern : patterns) {
+            if (pattern.matcher(key).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void captureHeader(String name, List<String> values,
+            Map<String, Object> header) {
+        if (values.isEmpty()) {
+            header.put(name, "");
+        } else {
+            final List<String> list = Lists.newArrayList();
+            for (final String value : values) {
+                list.add(Strings.nullToEmpty(value));
+            }
+            header.put(name, ImmutableList.copyOf(list));
+        }
+    }
+}

--- a/agent/plugins/java-http-server-plugin/src/main/java/org/glowroot/agent/plugin/javahttpserver/DetailCapture.java
+++ b/agent/plugins/java-http-server-plugin/src/main/java/org/glowroot/agent/plugin/javahttpserver/DetailCapture.java
@@ -33,13 +33,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-// shallow copies are necessary because request may not be thread safe, which may affect ability
-// to see detail from active traces
-//
-// shallow copies are also necessary because servlet container may clear out the objects after the
-// request is complete (e.g. tomcat does this) in order to reuse them, in which case this detail
-// would need to be captured synchronously at end of request anyways (although then it could be
-// captured only if trace met threshold for storage...)
 class DetailCapture {
 
     private DetailCapture() {}

--- a/agent/plugins/java-http-server-plugin/src/main/java/org/glowroot/agent/plugin/javahttpserver/HttpHandlerAspect.java
+++ b/agent/plugins/java-http-server-plugin/src/main/java/org/glowroot/agent/plugin/javahttpserver/HttpHandlerAspect.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.javahttpserver;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.glowroot.agent.plugin.api.Agent;
+import org.glowroot.agent.plugin.api.OptionalThreadContext;
+import org.glowroot.agent.plugin.api.ThreadContext;
+import org.glowroot.agent.plugin.api.ThreadContext.Priority;
+import org.glowroot.agent.plugin.api.TimerName;
+import org.glowroot.agent.plugin.api.TraceEntry;
+import org.glowroot.agent.plugin.api.util.FastThreadLocal;
+import org.glowroot.agent.plugin.api.weaving.BindParameter;
+import org.glowroot.agent.plugin.api.weaving.BindReturn;
+import org.glowroot.agent.plugin.api.weaving.BindThrowable;
+import org.glowroot.agent.plugin.api.weaving.BindTraveler;
+import org.glowroot.agent.plugin.api.weaving.IsEnabled;
+import org.glowroot.agent.plugin.api.weaving.OnAfter;
+import org.glowroot.agent.plugin.api.weaving.OnBefore;
+import org.glowroot.agent.plugin.api.weaving.OnReturn;
+import org.glowroot.agent.plugin.api.weaving.OnThrow;
+import org.glowroot.agent.plugin.api.weaving.Pointcut;
+import org.glowroot.agent.plugin.api.weaving.Shim;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+
+// this plugin is careful not to rely on request or session objects being thread-safe
+public class HttpHandlerAspect {
+
+    @Shim("com.sun.net.httpserver.HttpExchange")
+    public interface HttpExchange {
+
+        @Nullable
+        URI getRequestURI();
+
+        @Nullable
+        String getRequestMethod();
+
+        @Shim("com.sun.net.httpserver.Headers getRequestHeaders()")
+        @Nullable
+        Headers glowroot$getRequestHeaders();
+
+        @Shim("com.sun.net.httpserver.Headers getResponseHeaders()")
+        @Nullable
+        Headers glowroot$getResponseHeaders();
+
+        @Nullable
+        InetSocketAddress getRemoteAddress();
+
+    }
+
+    @Shim("com.sun.net.httpserver.Headers")
+    public interface Headers extends Map<String, List<String>> {
+
+        @Nullable
+        String getFirst(String key);
+
+    }
+
+    private static final FastThreadLocal</*@Nullable*/ String> sendError =
+            new FastThreadLocal</*@Nullable*/ String>();
+
+    @Pointcut(className = "com.sun.net.httpserver.HttpHandler", methodName = "handle",
+            methodParameterTypes = {"com.sun.net.httpserver.HttpExchange"},
+            nestingGroup = "outer-handler-or-filter", timerName = "http request")
+    public static class HandleAdvice {
+
+        private HandleAdvice() {
+            throw new IllegalAccessError();
+        }
+
+        private static final TimerName timerName = Agent.getTimerName(HandleAdvice.class);
+
+        @OnBefore
+        public static @Nullable TraceEntry onBefore(OptionalThreadContext context,
+                @BindParameter @Nullable HttpExchange exchange) {
+            return onBeforeCommon(context, exchange, null);
+        }
+
+        @OnReturn
+        public static void onReturn(@BindTraveler @Nullable TraceEntry traceEntry, @BindParameter @Nullable HttpExchange exchange) {
+            if (traceEntry == null) {
+                return;
+            }
+            FastThreadLocal.Holder</*@Nullable*/ String> errorMessageHolder = sendError.getHolder();
+            String errorMessage = errorMessageHolder.get();
+            setResponseHeaders(exchange, traceEntry.getMessageSupplier());
+            if (errorMessage != null) {
+                traceEntry.endWithError(errorMessage);
+                errorMessageHolder.set(null);
+            } else {
+                traceEntry.end();
+            }
+        }
+
+        @OnThrow
+        public static void onThrow(@BindThrowable Throwable t,
+                @BindTraveler @Nullable TraceEntry traceEntry, @BindParameter @Nullable HttpExchange exchange) {
+            if (traceEntry == null) {
+                return;
+            }
+            // ignoring potential sendError since this seems worse
+            sendError.set(null);
+            setResponseHeaders(exchange, traceEntry.getMessageSupplier());
+            traceEntry.endWithError(t);
+        }
+
+        private static void setResponseHeaders(@Nullable HttpExchange exchange, @Nullable Object messageSupplier) {
+            if (exchange != null && messageSupplier instanceof HttpHandlerMessageSupplier) {
+                ((HttpHandlerMessageSupplier) messageSupplier).setResponseHeaders(DetailCapture.captureResponseHeaders(exchange));
+            }
+        }
+
+        private static @Nullable TraceEntry onBeforeCommon(OptionalThreadContext context,
+                @Nullable HttpExchange exchange, @Nullable String transactionTypeOverride) {
+            if (exchange == null) {
+                // seems nothing sensible to do here other than ignore
+                return null;
+            }
+            final String requestUri = getRequestURI(exchange.getRequestURI());
+            final String requestQueryString = getRequestQueryString(exchange.getRequestURI());
+            final String requestMethod = Strings.nullToEmpty(exchange.getRequestMethod());
+            final ImmutableMap<String, Object> requestHeaders = DetailCapture.captureRequestHeaders(exchange);
+            final String requestRemoteAddr = DetailCapture.captureRequestRemoteAddr(exchange);
+            final String requestRemoteHost = DetailCapture.captureRequestRemoteHost(exchange);
+            final HttpHandlerMessageSupplier messageSupplier = new HttpHandlerMessageSupplier(requestMethod, requestUri,
+                        requestQueryString, requestHeaders, requestRemoteAddr, requestRemoteHost);
+            String transactionType = "Web";
+            boolean setWithCoreMaxPriority = false;
+            final Headers headers = exchange.glowroot$getRequestHeaders();
+            if (headers != null) {
+                final String transactionTypeHeader = headers.getFirst("Glowroot-Transaction-Type");
+                if (transactionTypeHeader != null && transactionTypeHeader.equals("Synthetic")) {
+                    // Glowroot-Transaction-Type header currently only accepts "Synthetic", in order to
+                    // prevent spamming of transaction types, which could cause some issues
+                    transactionType = transactionTypeHeader;
+                    setWithCoreMaxPriority = true;
+                } else if (transactionTypeOverride != null) {
+                    transactionType = transactionTypeOverride;
+                }
+            }
+            final TraceEntry traceEntry = context.startTransaction(transactionType, requestUri,
+                    messageSupplier, timerName);
+            if (setWithCoreMaxPriority) {
+                context.setTransactionType(transactionType, Priority.CORE_MAX);
+            }
+            // Glowroot-Transaction-Name header is useful for automated tests which want to send a
+            // more specific name for the transaction
+            if (headers != null) {
+                final String transactionNameOverride = headers.getFirst("Glowroot-Transaction-Name");
+                if (transactionNameOverride != null) {
+                    context.setTransactionName(transactionNameOverride, Priority.CORE_MAX);
+                }
+            }
+            return traceEntry;
+        }
+
+        private static String getRequestURI(@Nullable URI uri) {
+            if (uri != null) {
+                return Strings.nullToEmpty(uri.getPath());
+            } else {
+                return "";
+            }
+        }
+
+        private static @Nullable String getRequestQueryString(@Nullable URI uri) {
+            if (uri != null) {
+                return uri.getQuery();
+            } else {
+                return null;
+            }
+        }
+    }
+
+    @Pointcut(className = "com.sun.net.httpserver.Filter", methodName = "doFilter",
+            methodParameterTypes = {"com.sun.net.httpserver.HttpExchange", "com.sun.net.httpserver.Filter$Chain"},
+            nestingGroup = "outer-handler-or-filter", timerName = "http request")
+    public static class DoFilterAdvice {
+
+        private DoFilterAdvice() {
+            throw new IllegalAccessError();
+        }
+
+        @OnBefore
+        public static @Nullable TraceEntry onBefore(OptionalThreadContext context,
+                @BindParameter @Nullable HttpExchange exchange) {
+            return HandleAdvice.onBeforeCommon(context, exchange, null);
+        }
+
+        @OnReturn
+        public static void onReturn(@BindTraveler @Nullable TraceEntry traceEntry, @BindParameter @Nullable HttpExchange exchange) {
+            HandleAdvice.onReturn(traceEntry, exchange);
+        }
+
+        @OnThrow
+        public static void onThrow(@BindThrowable Throwable t,
+                @BindTraveler @Nullable TraceEntry traceEntry, @BindParameter @Nullable HttpExchange exchange) {
+            HandleAdvice.onThrow(t, traceEntry, exchange);
+        }
+    }
+
+    @Pointcut(className = "com.sun.net.httpserver.HttpExchange", methodName = "sendResponseHeaders",
+            methodParameterTypes = {"int", "long"}, nestingGroup = "handler-inner-call")
+    public static class SendResponseHeadersAdvice {
+
+        private SendResponseHeadersAdvice() {
+            throw new IllegalAccessError();
+        }
+
+        // using @IsEnabled like this avoids ThreadContext lookup for common case
+        @IsEnabled
+        public static boolean isEnabled(@BindParameter Integer statusCode) {
+            return statusCode >= 500;
+        }
+
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindParameter Integer statusCode) {
+            FastThreadLocal.Holder</*@Nullable*/ String> errorMessageHolder = sendError.getHolder();
+            if (errorMessageHolder.get() == null) {
+                context.addErrorEntry("sendResponseHeaders, HTTP status code " + statusCode);
+                errorMessageHolder.set("sendResponseHeaders, HTTP status code " + statusCode);
+            }
+        }
+    }
+
+    @Pointcut(className = "com.sun.net.httpserver.HttpExchange", methodName = "getPrincipal",
+            methodParameterTypes = {}, methodReturnType = "com.sun.net.httpserver.HttpPrincipal",
+            nestingGroup = "handler-inner-call")
+    public static class GetPrincipalAdvice {
+
+        private GetPrincipalAdvice() {
+            throw new IllegalAccessError();
+        }
+
+        @OnReturn
+        public static void onReturn(@BindReturn @Nullable Principal principal,
+                ThreadContext context) {
+            if (principal != null) {
+                context.setTransactionUser(principal.getName(), Priority.CORE_PLUGIN);
+            }
+        }
+    }
+}

--- a/agent/plugins/java-http-server-plugin/src/main/java/org/glowroot/agent/plugin/javahttpserver/HttpHandlerMessageSupplier.java
+++ b/agent/plugins/java-http-server-plugin/src/main/java/org/glowroot/agent/plugin/javahttpserver/HttpHandlerMessageSupplier.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.javahttpserver;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.glowroot.agent.plugin.api.Message;
+import org.glowroot.agent.plugin.api.MessageSupplier;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+class HttpHandlerMessageSupplier extends MessageSupplier {
+
+    private final String requestMethod;
+    private final String requestUri;
+    private final @Nullable String requestQueryString;
+
+    private final ImmutableMap<String, Object> requestHeaders;
+    private @Nullable ImmutableMap<String, Object> responseHeaders;
+
+    private final @Nullable String requestRemoteAddr;
+    private final @Nullable String requestRemoteHost;
+
+    HttpHandlerMessageSupplier(String requestMethod, String requestUri,
+            @Nullable String requestQueryString, ImmutableMap<String, Object> requestHeaders,
+            @Nullable String requestRemoteAddr, @Nullable String requestRemoteHost) {
+        this.requestMethod = requestMethod;
+        this.requestUri = requestUri;
+        this.requestQueryString = requestQueryString;
+        this.requestHeaders = requestHeaders;
+        this.requestRemoteAddr = requestRemoteAddr;
+        this.requestRemoteHost = requestRemoteHost;
+    }
+
+    @Override
+    public Message get() {
+        Map<String, Object> detail = Maps.newHashMap();
+        detail.put("Request http method", requestMethod);
+        if (requestQueryString != null) {
+            // including empty query string since that means request ended with ?
+            detail.put("Request query string", requestQueryString);
+        }
+        if (!requestHeaders.isEmpty()) {
+            detail.put("Request headers", requestHeaders);
+        }
+        if (requestRemoteAddr != null) {
+            detail.put("Request remote address", requestRemoteAddr);
+        }
+        if (requestRemoteHost != null) {
+            detail.put("Request remote host", requestRemoteHost);
+        }
+        if (responseHeaders != null && !responseHeaders.isEmpty()) {
+            detail.put("Response headers", responseHeaders);
+        }
+        return Message.create(requestUri, detail);
+    }
+
+    void setResponseHeaders(ImmutableMap<String, Object> responseHeaders) {
+        this.responseHeaders = responseHeaders;
+    }
+
+}

--- a/agent/plugins/java-http-server-plugin/src/main/java/org/glowroot/agent/plugin/javahttpserver/JavaHttpServerPluginProperties.java
+++ b/agent/plugins/java-http-server-plugin/src/main/java/org/glowroot/agent/plugin/javahttpserver/JavaHttpServerPluginProperties.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Lists;
 class JavaHttpServerPluginProperties {
 
     private static final String CAPTURE_REQUEST_HEADER_PROPERTY_NAME = "captureRequestHeaders";
+    private static final String MASK_REQUEST_HEADER_PROPERTY_NAME = "maskRequestHeaders";
     private static final String CAPTURE_REQUEST_REMOTE_ADDR_PROPERTY_NAME =
             "captureRequestRemoteAddr";
     private static final String CAPTURE_REQUEST_REMOTE_HOST_PROPERTY_NAME =
@@ -41,12 +42,12 @@ class JavaHttpServerPluginProperties {
     private static final Splitter splitter = Splitter.on(',').trimResults().omitEmptyStrings();
 
     private static ImmutableList<Pattern> captureRequestHeaders = ImmutableList.of();
+    private static ImmutableList<Pattern> maskRequestHeaders = ImmutableList.of();
 
     private static boolean captureRequestRemoteAddr;
     private static boolean captureRequestRemoteHost;
 
     private static ImmutableList<Pattern> captureResponseHeaders = ImmutableList.of();
-    private static boolean captureResponseHeadersNonEmpty;
 
     static {
         configService.registerConfigListener(new ServletPluginConfigListener());
@@ -56,6 +57,10 @@ class JavaHttpServerPluginProperties {
 
     static ImmutableList<Pattern> captureRequestHeaders() {
         return captureRequestHeaders;
+    }
+
+    static ImmutableList<Pattern> maskRequestHeaders() {
+        return maskRequestHeaders;
     }
 
     static boolean captureRequestRemoteAddr() {
@@ -70,10 +75,6 @@ class JavaHttpServerPluginProperties {
         return captureResponseHeaders;
     }
 
-    static boolean captureResponseHeadersNonEmpty() {
-        return captureResponseHeadersNonEmpty;
-    }
-
     private static class ServletPluginConfigListener implements ConfigListener {
 
         @Override
@@ -83,12 +84,12 @@ class JavaHttpServerPluginProperties {
 
         private static void recalculateProperties() {
             captureRequestHeaders = buildPatternList(CAPTURE_REQUEST_HEADER_PROPERTY_NAME);
+            maskRequestHeaders = buildPatternList(MASK_REQUEST_HEADER_PROPERTY_NAME);
             captureRequestRemoteAddr = configService
                     .getBooleanProperty(CAPTURE_REQUEST_REMOTE_ADDR_PROPERTY_NAME).value();
             captureRequestRemoteHost = configService
                     .getBooleanProperty(CAPTURE_REQUEST_REMOTE_HOST_PROPERTY_NAME).value();
             captureResponseHeaders = buildPatternList(CAPTURE_RESPONSE_HEADER_PROPERTY_NAME);
-            captureResponseHeadersNonEmpty = !captureResponseHeaders.isEmpty();
         }
 
         private static ImmutableList<Pattern> buildPatternList(String propertyName) {

--- a/agent/plugins/java-http-server-plugin/src/main/java/org/glowroot/agent/plugin/javahttpserver/JavaHttpServerPluginProperties.java
+++ b/agent/plugins/java-http-server-plugin/src/main/java/org/glowroot/agent/plugin/javahttpserver/JavaHttpServerPluginProperties.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.javahttpserver;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import org.glowroot.agent.plugin.api.Agent;
+import org.glowroot.agent.plugin.api.config.ConfigListener;
+import org.glowroot.agent.plugin.api.config.ConfigService;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+class JavaHttpServerPluginProperties {
+
+    private static final String CAPTURE_REQUEST_HEADER_PROPERTY_NAME = "captureRequestHeaders";
+    private static final String CAPTURE_REQUEST_REMOTE_ADDR_PROPERTY_NAME =
+            "captureRequestRemoteAddr";
+    private static final String CAPTURE_REQUEST_REMOTE_HOST_PROPERTY_NAME =
+            "captureRequestRemoteHost";
+    private static final String CAPTURE_RESPONSE_HEADER_PROPERTY_NAME = "captureResponseHeaders";
+
+    private static final ConfigService configService = Agent.getConfigService("javahttpserver");
+
+    private static final Splitter splitter = Splitter.on(',').trimResults().omitEmptyStrings();
+
+    private static ImmutableList<Pattern> captureRequestHeaders = ImmutableList.of();
+
+    private static boolean captureRequestRemoteAddr;
+    private static boolean captureRequestRemoteHost;
+
+    private static ImmutableList<Pattern> captureResponseHeaders = ImmutableList.of();
+    private static boolean captureResponseHeadersNonEmpty;
+
+    static {
+        configService.registerConfigListener(new ServletPluginConfigListener());
+    }
+
+    private JavaHttpServerPluginProperties() {}
+
+    static ImmutableList<Pattern> captureRequestHeaders() {
+        return captureRequestHeaders;
+    }
+
+    static boolean captureRequestRemoteAddr() {
+        return captureRequestRemoteAddr;
+    }
+
+    static boolean captureRequestRemoteHost() {
+        return captureRequestRemoteHost;
+    }
+
+    static ImmutableList<Pattern> captureResponseHeaders() {
+        return captureResponseHeaders;
+    }
+
+    static boolean captureResponseHeadersNonEmpty() {
+        return captureResponseHeadersNonEmpty;
+    }
+
+    private static class ServletPluginConfigListener implements ConfigListener {
+
+        @Override
+        public void onChange() {
+            recalculateProperties();
+        }
+
+        private static void recalculateProperties() {
+            captureRequestHeaders = buildPatternList(CAPTURE_REQUEST_HEADER_PROPERTY_NAME);
+            captureRequestRemoteAddr = configService
+                    .getBooleanProperty(CAPTURE_REQUEST_REMOTE_ADDR_PROPERTY_NAME).value();
+            captureRequestRemoteHost = configService
+                    .getBooleanProperty(CAPTURE_REQUEST_REMOTE_HOST_PROPERTY_NAME).value();
+            captureResponseHeaders = buildPatternList(CAPTURE_RESPONSE_HEADER_PROPERTY_NAME);
+            captureResponseHeadersNonEmpty = !captureResponseHeaders.isEmpty();
+        }
+
+        private static ImmutableList<Pattern> buildPatternList(String propertyName) {
+            String captureRequestParametersText =
+                    configService.getStringProperty(propertyName).value();
+            List<Pattern> captureParameters = Lists.newArrayList();
+            for (String parameter : splitter.split(captureRequestParametersText)) {
+                // converted to lower case for case-insensitive matching
+                captureParameters.add(buildRegexPattern(parameter.toLowerCase(Locale.ENGLISH)));
+            }
+            return ImmutableList.copyOf(captureParameters);
+        }
+
+        private static Pattern buildRegexPattern(String wildcardPattern) {
+            // convert * into .* and quote the rest of the text using \Q...\E
+            String regex = "\\Q" + wildcardPattern.replace("*", "\\E.*\\Q") + "\\E";
+            // strip off unnecessary \\Q\\E in case * appeared at beginning or end of part
+            regex = regex.replace("\\Q\\E", "");
+            return Pattern.compile(regex);
+        }
+    }
+}

--- a/agent/plugins/java-http-server-plugin/src/main/resources/META-INF/glowroot.plugin.json
+++ b/agent/plugins/java-http-server-plugin/src/main/resources/META-INF/glowroot.plugin.json
@@ -9,6 +9,13 @@
       "description": "Comma-separated list of request headers to capture in the root trace entry. The wildcard '*' is supported anywhere in the parameter."
     },
     {
+      "name": "maskRequestHeaders",
+      "type": "string",
+      "default": "Authorization",
+      "label": "Mask request headers",
+      "description": "Comma-separated list of sensitive request headers to mask, e.g. credentials. The wildcard '*' is supported anywhere in the parameter."
+    },
+    {
       "name": "captureRequestRemoteAddr",
       "type": "boolean",
       "label": "Capture request remote address",
@@ -18,7 +25,7 @@
       "name": "captureRequestRemoteHost",
       "type": "boolean",
       "label": "Capture request remote host",
-      "description": "Capture request remote host using HttpExchange.getRemoteAddress().getHostString()."
+      "description": "Capture request remote host using HttpExchange.getRemoteAddress().getHostName()."
     },
     {
       "name": "captureResponseHeaders",

--- a/agent/plugins/java-http-server-plugin/src/main/resources/META-INF/glowroot.plugin.json
+++ b/agent/plugins/java-http-server-plugin/src/main/resources/META-INF/glowroot.plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "Java HTTP Server Plugin",
+  "id": "javahttpserver",
+  "properties": [
+    {
+      "name": "captureRequestHeaders",
+      "type": "string",
+      "label": "Capture request headers",
+      "description": "Comma-separated list of request headers to capture in the root trace entry. The wildcard '*' is supported anywhere in the parameter."
+    },
+    {
+      "name": "captureRequestRemoteAddr",
+      "type": "boolean",
+      "label": "Capture request remote address",
+      "description": "Capture request remote address using HttpExchange.getRemoteAddress().getAddress().getHostAddress()."
+    },
+    {
+      "name": "captureRequestRemoteHost",
+      "type": "boolean",
+      "label": "Capture request remote host",
+      "description": "Capture request remote host using HttpExchange.getRemoteAddress().getHostString()."
+    },
+    {
+      "name": "captureResponseHeaders",
+      "type": "string",
+      "label": "Capture response headers",
+      "description": "Comma-separated list of response headers to capture in the root trace entry. The wildcard '*' is supported anywhere in the parameter."
+    }
+  ],
+  "aspects": [
+    "org.glowroot.agent.plugin.javahttpserver.HttpHandlerAspect"
+  ]
+}

--- a/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/JavaHttpServerPluginIT.java
+++ b/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/JavaHttpServerPluginIT.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.javahttpserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import javax.annotation.Nullable;
+
+import org.glowroot.agent.it.harness.Container;
+import org.glowroot.agent.it.harness.Containers;
+import org.glowroot.wire.api.model.TraceOuterClass.Trace;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.sun.net.httpserver.HttpExchange;
+
+@SuppressWarnings("restriction")
+public class JavaHttpServerPluginIT {
+
+    private static Container container;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        container = Containers.create();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        container.close();
+    }
+
+    @After
+    public void afterEachTest() throws Exception {
+        container.checkAndReset();
+    }
+
+    @Test
+    public void testHandler() throws Exception {
+        // when
+        Trace trace = container.execute(ExecuteHandler.class, "Web");
+
+        // then
+        Trace.Header header = trace.getHeader();
+        assertThat(header.getHeadline()).isEqualTo("/testhandler");
+        assertThat(header.getTransactionName()).isEqualTo("/testhandler");
+        assertThat(getDetailValue(header, "Request http method")).isEqualTo("GET");
+        assertThat(header.getEntryCount()).isZero();
+    }
+
+    @Test
+    public void testFilter() throws Exception {
+        // when
+        Trace trace = container.execute(ExecuteFilter.class, "Web");
+
+        // then
+        Trace.Header header = trace.getHeader();
+        assertThat(header.getHeadline()).isEqualTo("/testfilter");
+        assertThat(header.getTransactionName()).isEqualTo("/testfilter");
+        assertThat(getDetailValue(header, "Request http method")).isEqualTo("GET");
+        assertThat(header.getEntryCount()).isZero();
+    }
+
+    @Test
+    public void testCombination() throws Exception {
+        // when
+        Trace trace = container.execute(ExecuteFilterWithNestedHandler.class, "Web");
+
+        // then
+        Trace.Header header = trace.getHeader();
+        assertThat(header.getHeadline()).isEqualTo("/testfilter");
+        assertThat(header.getTransactionName()).isEqualTo("/testfilter");
+        assertThat(getDetailValue(header, "Request http method")).isEqualTo("GET");
+        assertThat(header.getEntryCount()).isZero();
+    }
+
+    @Test
+    public void testNoQueryString() throws Exception {
+        // when
+        Trace trace = container.execute(TestNoQueryString.class, "Web");
+        // then
+        assertThat(getDetailValue(trace.getHeader(), "Request query string")).isNull();
+        assertThat(trace.getHeader().getEntryCount()).isZero();
+    }
+
+    @Test
+    public void testEmptyQueryString() throws Exception {
+        // when
+        Trace trace = container.execute(TestEmptyQueryString.class, "Web");
+        // then
+        assertThat(getDetailValue(trace.getHeader(), "Request query string")).isEqualTo("");
+        assertThat(trace.getHeader().getEntryCount()).isZero();
+    }
+
+    @Test
+    public void testNonEmptyQueryString() throws Exception {
+        // when
+        Trace trace = container.execute(TestNonEmptyQueryString.class, "Web");
+        // then
+        assertThat(getDetailValue(trace.getHeader(), "Request query string")).isEqualTo("a=b&c=d");
+        assertThat(trace.getHeader().getEntryCount()).isZero();
+    }
+
+    @Test
+    public void testHandlerThrowsException() throws Exception {
+        // when
+        Trace trace = container.execute(HandlerThrowsException.class, "Web");
+
+        // then
+        Trace.Header header = trace.getHeader();
+        assertThat(header.getError().getMessage()).isNotEmpty();
+        assertThat(header.getError().hasException()).isTrue();
+        assertThat(header.getEntryCount()).isZero();
+    }
+
+    @Test
+    public void testFilterThrowsException() throws Exception {
+        // when
+        Trace trace = container.execute(FilterThrowsException.class, "Web");
+
+        // then
+        Trace.Header header = trace.getHeader();
+        assertThat(header.getError().getMessage()).isNotEmpty();
+        assertThat(header.getError().hasException()).isTrue();
+        assertThat(header.getEntryCount()).isZero();
+    }
+
+    @Test
+    public void testSend500Error() throws Exception {
+        // when
+        Trace trace = container.execute(Send500Error.class, "Web");
+
+        // then
+        assertThat(trace.getHeader().getError().getMessage())
+                .isEqualTo("sendResponseHeaders, HTTP status code 500");
+        assertThat(trace.getHeader().getError().hasException()).isFalse();
+
+        Iterator<Trace.Entry> i = trace.getEntryList().iterator();
+
+        Trace.Entry entry = i.next();
+        assertThat(entry.getError().getMessage()).isEqualTo("sendResponseHeaders, HTTP status code 500");
+        assertThat(entry.getError().hasException()).isFalse();
+        assertThat(entry.getLocationStackTraceElementList()).isNotEmpty();
+        assertThat(entry.getLocationStackTraceElementList().get(0).getMethodName())
+                .isEqualTo("sendResponseHeaders");
+
+        assertThat(i.hasNext()).isFalse();
+    }
+
+    private static @Nullable String getDetailValue(Trace.Header header, String name) {
+        for (Trace.DetailEntry detail : header.getDetailEntryList()) {
+            if (detail.getName().equals(name)) {
+                return detail.getValueList().get(0).getString();
+            }
+        }
+        return null;
+    }
+
+    public static class ExecuteHandler extends TestHandler {}
+
+    public static class ExecuteFilter extends TestFilter {}
+
+    public static class ExecuteFilterWithNestedHandler extends TestFilter {
+        @Override
+        public void doFilter(HttpExchange exchange, Chain chain)
+                throws IOException {
+            new TestFilter().doFilter(exchange, chain);
+        }
+    }
+
+    public static class TestNoQueryString extends TestHandler {
+        @Override
+        protected void before(HttpExchange exchange) {
+            ((MockHttpExchange) exchange).setQueryString(null);
+        }
+    }
+
+    public static class TestEmptyQueryString extends TestHandler {
+        @Override
+        protected void before(HttpExchange exchange) {
+            ((MockHttpExchange) exchange).setQueryString("");
+        }
+    }
+
+    public static class TestNonEmptyQueryString extends TestHandler {
+        @Override
+        protected void before(HttpExchange exchange) {
+            ((MockHttpExchange) exchange).setQueryString("a=b&c=d");
+        }
+    }
+
+    public static class HandlerThrowsException extends TestHandler {
+        private final RuntimeException exception = new RuntimeException("Something happened");
+        @Override
+        public void executeApp() throws Exception {
+            try {
+                super.executeApp();
+            } catch (RuntimeException e) {
+                // only suppress expected exception
+                if (e != exception) {
+                    throw e;
+                }
+            }
+        }
+        @Override
+        public void handle(HttpExchange exchange) {
+            throw exception;
+        }
+    }
+
+    public static class FilterThrowsException extends TestFilter {
+        private final RuntimeException exception = new RuntimeException("Something happened");
+        @Override
+        public void executeApp() throws Exception {
+            try {
+                super.executeApp();
+            } catch (RuntimeException e) {
+                // only suppress expected exception
+                if (e != exception) {
+                    throw e;
+                }
+            }
+        }
+        @Override
+        public void doFilter(HttpExchange exchange, Chain chain) {
+            throw exception;
+        }
+    }
+
+    public static class Send500Error extends TestHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            exchange.sendResponseHeaders(500, 0);
+        }
+    }
+
+    public static class NestedTwo {
+        private final String two;
+        public NestedTwo(String two) {
+            this.two = two;
+        }
+        public String getTwo() {
+            return two;
+        }
+    }
+}

--- a/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/MockHttpExchange.java
+++ b/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/MockHttpExchange.java
@@ -1,0 +1,143 @@
+package org.glowroot.agent.plugin.javahttpserver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.glowroot.agent.plugin.javahttpserver.HttpHandlerAspect.HttpExchange;
+
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpPrincipal;
+
+@SuppressWarnings("restriction")
+public class MockHttpExchange extends com.sun.net.httpserver.HttpExchange implements HttpExchange {
+
+    private String requestURI;
+    private String method;
+
+    private final PatchedHeaders requestHeaders;
+    private final PatchedHeaders responseHeaders;
+    private String queryString = "";
+    private int statusCode;
+
+    public MockHttpExchange(String method, String requestURI) {
+        this.method = method;
+        this.requestURI = requestURI;
+        this.requestHeaders = new PatchedHeaders();
+        this.responseHeaders = new PatchedHeaders();
+    }
+
+    public MockHttpExchange() {
+        this("", "");
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public Object getAttribute(String arg0) {
+        return null;
+    }
+
+    @Override
+    public HttpContext getHttpContext() {
+        return null;
+    }
+
+    @Override
+    public InetSocketAddress getLocalAddress() {
+        return null;
+    }
+
+    @Override
+    public HttpPrincipal getPrincipal() {
+        return null;
+    }
+
+    @Override
+    public String getProtocol() {
+        return null;
+    }
+
+    @Override
+    public InetSocketAddress getRemoteAddress() {
+        return null;
+    }
+
+    @Override
+    public InputStream getRequestBody() {
+        return null;
+    }
+
+    @Override
+    public PatchedHeaders getRequestHeaders() {
+        return requestHeaders;
+    }
+
+    @Override
+    public String getRequestMethod() {
+        return method;
+    }
+
+    @Override
+    public URI getRequestURI() {
+        String str = "http://localhost:80" + requestURI;
+        if (queryString != null) {
+            str += "?" + queryString;
+        }
+        try {
+            return new URI(str);
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public OutputStream getResponseBody() {
+        return null;
+    }
+
+    @Override
+    public int getResponseCode() {
+        return 0;
+    }
+
+    @Override
+    public PatchedHeaders getResponseHeaders() {
+        return responseHeaders;
+    }
+
+    @Override
+    public void sendResponseHeaders(int statusCode, long contentLength) throws IOException {
+        this.statusCode = statusCode;
+        this.responseHeaders.set("Content-Length", Long.toString(contentLength));
+    }
+
+    @Override
+    public void setAttribute(String arg0, Object arg1) {}
+
+    @Override
+    public void setStreams(InputStream arg0, OutputStream arg1) {}
+
+    @Override
+    public PatchedHeaders glowroot$getRequestHeaders() {
+        return getRequestHeaders();
+    }
+
+    @Override
+    public PatchedHeaders glowroot$getResponseHeaders() {
+        return getResponseHeaders();
+    }
+
+    void setQueryString(String queryString) {
+        this.queryString = queryString;
+    }
+
+    int getStatusCode() {
+        return statusCode;
+    }
+
+}

--- a/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/MockHttpExchange.java
+++ b/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/MockHttpExchange.java
@@ -21,7 +21,7 @@ public class MockHttpExchange extends com.sun.net.httpserver.HttpExchange implem
     private final PatchedHeaders requestHeaders;
     private final PatchedHeaders responseHeaders;
     private String queryString = "";
-    private int statusCode;
+    private HttpPrincipal principal;
 
     public MockHttpExchange(String method, String requestURI) {
         this.method = method;
@@ -54,7 +54,7 @@ public class MockHttpExchange extends com.sun.net.httpserver.HttpExchange implem
 
     @Override
     public HttpPrincipal getPrincipal() {
-        return null;
+        return principal;
     }
 
     @Override
@@ -112,7 +112,6 @@ public class MockHttpExchange extends com.sun.net.httpserver.HttpExchange implem
 
     @Override
     public void sendResponseHeaders(int statusCode, long contentLength) throws IOException {
-        this.statusCode = statusCode;
         this.responseHeaders.set("Content-Length", Long.toString(contentLength));
     }
 
@@ -136,8 +135,8 @@ public class MockHttpExchange extends com.sun.net.httpserver.HttpExchange implem
         this.queryString = queryString;
     }
 
-    int getStatusCode() {
-        return statusCode;
+    void setPrincipal(HttpPrincipal principal) {
+        this.principal = principal;
     }
 
 }

--- a/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/PatchedHeaders.java
+++ b/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/PatchedHeaders.java
@@ -1,0 +1,6 @@
+package org.glowroot.agent.plugin.javahttpserver;
+
+@SuppressWarnings("restriction")
+public class PatchedHeaders extends com.sun.net.httpserver.Headers implements org.glowroot.agent.plugin.javahttpserver.HttpHandlerAspect.Headers {
+
+}

--- a/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/RequestHeaderIT.java
+++ b/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/RequestHeaderIT.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.javahttpserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.glowroot.agent.it.harness.Container;
+import org.glowroot.agent.it.harness.Containers;
+import org.glowroot.wire.api.model.TraceOuterClass.Trace;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.sun.net.httpserver.HttpExchange;
+
+// The com.sun.net.httpserver.Headers class normalizes the header keys by
+// converting to following form: first char upper case, rest lower case.
+@SuppressWarnings("restriction")
+public class RequestHeaderIT {
+
+    private static final String PLUGIN_ID = "javahttpserver";
+
+    private static Container container;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        container = Containers.create();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        container.close();
+    }
+
+    @After
+    public void afterEachTest() throws Exception {
+        container.checkAndReset();
+    }
+
+    @Test
+    public void testStandardRequestHeaders() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID, "captureRequestHeaders",
+                "Content-Type, Content-Length");
+
+        // when
+        Trace trace = container.execute(SetStandardRequestHeaders.class, "Web");
+
+        // then
+        Map<String, Object> requestHeaders = ResponseHeaderIT.getDetailMap(trace, "Request headers");
+        assertThat(requestHeaders.get("Content-type")).isEqualTo("text/plain;charset=UTF-8");
+        assertThat(requestHeaders.get("Content-length")).isEqualTo("1");
+        assertThat(requestHeaders.get("Extra")).isNull();
+    }
+
+    @Test
+    public void testStandardRequestHeadersLowercase() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID, "captureRequestHeaders",
+                "Content-Type, Content-Length");
+
+        // when
+        Trace trace = container.execute(SetStandardRequestHeadersLowercase.class, "Web");
+
+        // then
+        Map<String, Object> requestHeaders = ResponseHeaderIT.getDetailMap(trace, "Request headers");
+        assertThat(requestHeaders.get("Content-type")).isEqualTo("text/plain;charset=UTF-8");
+        assertThat(requestHeaders.get("Content-length")).isEqualTo("1");
+        assertThat(requestHeaders.get("Extra")).isNull();
+    }
+
+    @Test
+    public void testLotsOfRequestHeaders() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID, "captureRequestHeaders", "One,two");
+
+        // when
+        Trace trace = container.execute(SetOtherRequestHeaders.class, "Web");
+
+        // then
+        Map<String, Object> requestHeaders = ResponseHeaderIT.getDetailMap(trace, "Request headers");
+        @SuppressWarnings("unchecked")
+        List<String> one = (List<String>) requestHeaders.get("One");
+        assertThat(one).containsExactly("ab", "xy");
+        assertThat(requestHeaders.get("Two")).isEqualTo("1");
+        assertThat(requestHeaders.get("Three")).isNull();
+    }
+
+    public static class SetStandardRequestHeaders extends TestHandler {
+        @Override
+        protected void before(HttpExchange exchange) {
+            exchange.getRequestHeaders().add("Content-Type", "text/plain;charset=UTF-8");
+            exchange.getRequestHeaders().add("Content-Length", "1");
+            exchange.getRequestHeaders().add("Extra", "abc");
+        }
+    }
+
+    public static class SetStandardRequestHeadersLowercase extends TestHandler {
+        @Override
+        protected void before(HttpExchange exchange) {
+            exchange.getRequestHeaders().add("content-type", "text/plain;charset=UTF-8");
+            exchange.getRequestHeaders().add("content-length", "1");
+            exchange.getRequestHeaders().add("extra", "abc");
+        }
+    }
+
+    public static class SetOtherRequestHeaders extends TestHandler {
+        @Override
+        protected void before(HttpExchange exchange) {
+            exchange.getRequestHeaders().add("One", "ab");
+            exchange.getRequestHeaders().add("One", "xy");
+            exchange.getRequestHeaders().add("Two", "1");
+            exchange.getRequestHeaders().add("Three", "xyz");
+        }
+    }
+
+}

--- a/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/ResponseHeaderIT.java
+++ b/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/ResponseHeaderIT.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.javahttpserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.glowroot.agent.it.harness.AppUnderTest;
+import org.glowroot.agent.it.harness.Container;
+import org.glowroot.agent.it.harness.Containers;
+import org.glowroot.wire.api.model.TraceOuterClass.Trace;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.sun.net.httpserver.HttpExchange;
+
+@SuppressWarnings("restriction")
+public class ResponseHeaderIT {
+
+    private static final String PLUGIN_ID = "javahttpserver";
+
+    private static Container container;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        container = Containers.create();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        container.close();
+    }
+
+    @After
+    public void afterEachTest() throws Exception {
+        container.checkAndReset();
+    }
+
+    @Test
+    public void testStandardResponseHeadersUsingSetHeader() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID, "captureResponseHeaders",
+                "Content-Type, Content-Length, Content-Language");
+
+        // when
+        Trace trace = container.execute(SetStandardResponseHeadersUsingSetHeader.class, "Web");
+
+        // then
+        Map<String, Object> responseHeaders = getResponseHeaders(trace);
+        assertThat(responseHeaders.get("Content-type")).isEqualTo("text/plain;charset=UTF-8");
+        assertThat(responseHeaders.get("Content-length")).isEqualTo("1");
+        assertThat(responseHeaders.get("Content-language")).isEqualTo("en");
+        assertThat(responseHeaders.get("Extra")).isNull();
+    }
+
+    @Test
+    public void testStandardResponseHeadersUsingAddHeader() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID, "captureResponseHeaders",
+                "Content-Type, Content-Length, Content-Language");
+
+        // when
+        Trace trace = container.execute(SetStandardResponseHeadersUsingAddHeader.class, "Web");
+
+        // then
+        Map<String, Object> responseHeaders = getResponseHeaders(trace);
+        assertThat(responseHeaders.get("Content-type")).isEqualTo("text/plain;charset=UTF-8");
+        assertThat(responseHeaders.get("Content-length")).isEqualTo("1");
+        assertThat(responseHeaders.get("Content-language")).isEqualTo("en");
+        assertThat(responseHeaders.get("Extra")).isNull();
+    }
+
+    @Test
+    public void testStandardResponseHeadersLowercase() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID, "captureResponseHeaders",
+                "Content-Type, Content-Length");
+
+        // when
+        Trace trace = container.execute(SetStandardResponseHeadersLowercase.class, "Web");
+
+        // then
+        Map<String, Object> responseHeaders = getResponseHeaders(trace);
+        assertThat(responseHeaders.get("Content-type")).isEqualTo("text/plain;charset=UTF-8");
+        assertThat(responseHeaders.get("Content-length")).isEqualTo("1");
+        assertThat(responseHeaders.get("Extra")).isNull();
+    }
+
+    @Test
+    public void testWithoutAnyHeaderCaptureUsingSetHeader() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID, "captureResponseHeaders", "");
+        // when
+        Trace trace = container.execute(SetStandardResponseHeadersUsingSetHeader.class, "Web");
+        // then
+        assertThat(getResponseHeaders(trace)).isNull();
+    }
+
+    @Test
+    public void testWithoutAnyHeaderCaptureUsingAddHeader() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID, "captureResponseHeaders", "");
+        // when
+        Trace trace = container.execute(SetStandardResponseHeadersUsingAddHeader.class, "Web");
+        // then
+        assertThat(getResponseHeaders(trace)).isNull();
+    }
+
+    @Test
+    public void testLotsOfResponseHeaders() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID, "captureResponseHeaders",
+                "One,Two,Date-One,Date-Two,Int-One,Int-Two,X-One");
+
+        // when
+        Trace trace = container.execute(SetLotsOfResponseHeaders.class, "Web");
+
+        // then
+        Map<String, Object> responseHeaders = getResponseHeaders(trace);
+        @SuppressWarnings("unchecked")
+        List<String> one = (List<String>) responseHeaders.get("One");
+        @SuppressWarnings("unchecked")
+        List<String> iOne = (List<String>) responseHeaders.get("Int-one");
+        assertThat(one).containsExactly("ab", "xy");
+        assertThat(responseHeaders.get("Two")).isEqualTo("1");
+        assertThat(responseHeaders.get("Three")).isNull();
+        assertThat(responseHeaders.get("Date-three")).isNull();
+        assertThat(iOne).containsExactly("2", "3");
+        assertThat(responseHeaders.get("Int-two")).isEqualTo("4");
+        assertThat(responseHeaders.get("Int-three")).isNull();
+    }
+
+    @Test
+    public void testOutsideServlet() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID, "captureResponseHeaders",
+                "Content-Type, Content-Length, Content-Language");
+        // when
+        container.executeNoExpectedTrace(SetStandardResponseHeadersOutsideServlet.class);
+        // then
+        // basically just testing that it should not generate any errors
+    }
+
+    static @Nullable Map<String, Object> getDetailMap(Trace trace, String name) {
+        List<Trace.DetailEntry> details = trace.getHeader().getDetailEntryList();
+        Trace.DetailEntry found = null;
+        for (Trace.DetailEntry detail : details) {
+            if (detail.getName().equals(name)) {
+                found = detail;
+                break;
+            }
+        }
+        if (found == null) {
+            return null;
+        }
+        Map<String, Object> responseHeaders = Maps.newLinkedHashMap();
+        for (Trace.DetailEntry detail : found.getChildEntryList()) {
+            List<Trace.DetailValue> values = detail.getValueList();
+            if (values.size() == 1) {
+                responseHeaders.put(detail.getName(), values.get(0).getString());
+            } else {
+                List<String> vals = Lists.newArrayList();
+                for (Trace.DetailValue value : values) {
+                    vals.add(value.getString());
+                }
+                responseHeaders.put(detail.getName(), vals);
+            }
+        }
+        return responseHeaders;
+    }
+
+    private static @Nullable Map<String, Object> getResponseHeaders(Trace trace) {
+        return getDetailMap(trace, "Response headers");
+    }
+
+    public static class SetStandardResponseHeadersUsingSetHeader extends TestHandler {
+        @Override
+        public void handle(HttpExchange exchange)  {
+            exchange.getResponseHeaders().set("Content-Type", "text/plain;charset=UTF-8");
+            exchange.getResponseHeaders().set("Content-Length", "1");
+            exchange.getResponseHeaders().set("Extra", "abc");
+            exchange.getResponseHeaders().set("Content-Language", Locale.ENGLISH.getLanguage());
+        }
+    }
+
+    public static class SetStandardResponseHeadersUsingAddHeader extends TestHandler {
+        @Override
+        public void handle(HttpExchange exchange)  {
+            exchange.getResponseHeaders().add("Content-Type", "text/plain;charset=UTF-8");
+            exchange.getResponseHeaders().add("Content-Length", "1");
+            exchange.getResponseHeaders().add("Extra", "abc");
+            exchange.getResponseHeaders().add("Content-Language", Locale.ENGLISH.getLanguage());
+        }
+    }
+
+    public static class SetStandardResponseHeadersLowercase extends TestHandler {
+        @Override
+        public void handle(HttpExchange exchange)  {
+            exchange.getResponseHeaders().set("content-type", "text/plain;charset=UTF-8");
+            exchange.getResponseHeaders().set("content-length", "1");
+            exchange.getResponseHeaders().set("extra", "abc");
+        }
+    }
+
+    public static class SetLotsOfResponseHeaders extends TestHandler {
+        @Override
+        public void handle(HttpExchange exchange)  {
+            exchange.getResponseHeaders().set("One", "abc");
+            exchange.getResponseHeaders().set("one", "ab");
+            exchange.getResponseHeaders().add("one", "xy");
+            exchange.getResponseHeaders().set("Two", "1");
+            exchange.getResponseHeaders().set("Three", "xyz");
+
+            exchange.getResponseHeaders().set("Int-One", "1");
+            exchange.getResponseHeaders().set("Int-one", "2");
+            exchange.getResponseHeaders().add("Int-one", "3");
+            exchange.getResponseHeaders().set("Int-Two", "4");
+            exchange.getResponseHeaders().set("Int-Thr", "5");
+            exchange.getResponseHeaders().add("Int-Four", "6");
+
+            exchange.getResponseHeaders().add("X-One", "xy");
+            exchange.getResponseHeaders().add("X-one", "6");
+        }
+    }
+
+    public static class SetStandardResponseHeadersOutsideServlet implements AppUnderTest {
+        @Override
+        public void executeApp() throws Exception {
+            MockHttpExchange exchange = new MockHttpExchange();
+            exchange.getResponseHeaders().set("Content-Length", "1");
+            exchange.getResponseHeaders().set("Content-Type", "text/plain");
+            exchange.getResponseHeaders().set("Character-Encoding", "UTF-8");
+            exchange.getResponseHeaders().set("Content-Language", Locale.ENGLISH.getLanguage());
+        }
+    }
+}

--- a/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/TestFilter.java
+++ b/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/TestFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.javahttpserver;
+
+import java.io.IOException;
+
+import org.glowroot.agent.it.harness.AppUnderTest;
+
+import com.sun.net.httpserver.Filter;
+import com.sun.net.httpserver.HttpExchange;
+
+@SuppressWarnings("restriction")
+class TestFilter extends Filter implements AppUnderTest {
+
+    @Override
+    public void executeApp() throws Exception {
+        MockHttpExchange exchange = new MockHttpExchange("GET", "/testfilter");
+        doFilter(exchange, null);
+    }
+
+    @Override
+    public String description() {
+        return getClass().getSimpleName();
+    }
+   
+    @Override
+    public void doFilter(HttpExchange exchange, Chain chain) throws IOException {}
+
+}

--- a/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/TestHandler.java
+++ b/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/TestHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.javahttpserver;
+
+import java.io.IOException;
+
+import org.glowroot.agent.it.harness.AppUnderTest;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+@SuppressWarnings({ "restriction" })
+class TestHandler implements HttpHandler, AppUnderTest {
+
+    @Override
+    public void executeApp() throws Exception {
+        MockHttpExchange exchange = new MockHttpExchange("GET", "/testhandler");
+        before(exchange);
+        handle(exchange);
+    }
+
+    // hook for subclasses
+    protected void before(HttpExchange exchange) {}
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {}
+
+}

--- a/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/UserIT.java
+++ b/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/UserIT.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.javahttpserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.glowroot.agent.it.harness.Container;
+import org.glowroot.agent.it.harness.Containers;
+import org.glowroot.wire.api.model.TraceOuterClass.Trace;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpPrincipal;
+
+@SuppressWarnings("restriction")
+public class UserIT {
+
+    private static final String PRINCIPAL_NAME = "my name is mock";
+
+    private static Container container;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        container = Containers.create();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        container.close();
+    }
+
+    @After
+    public void afterEachTest() throws Exception {
+        container.checkAndReset();
+    }
+
+    @Test
+    public void testHasExchangePrincipal() throws Exception {
+        // when
+        Trace trace = container.execute(HasExchangePrincipal.class, "Web");
+        // then
+        assertThat(trace.getHeader().getUser()).isEqualTo(PRINCIPAL_NAME);
+    }
+
+    @Test
+    public void testHasExchangeWithExceptionOnGetPrincipal() throws Exception {
+        // when
+        container.execute(HasExchangeWithExceptionOnGetPrincipal.class, "Web");
+        // then don't blow up
+    }
+
+    public static class HasExchangePrincipal extends TestHandler {
+        @Override
+        protected void before(HttpExchange exchange) {
+            ((MockHttpExchange) exchange).setPrincipal(new HttpPrincipal(PRINCIPAL_NAME, "my realm"));
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) {
+            // user principal is only captured if app actually uses it
+            // (since it may throw exception)
+            exchange.getPrincipal();
+        }
+    }
+
+    public static class HasExchangeWithExceptionOnGetPrincipal extends TestHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            super.handle(new PrincipalThrowingMockHttpExchange("GET", "/testhandler"));
+        }
+    }
+
+    public static class PrincipalThrowingMockHttpExchange extends MockHttpExchange {
+        public PrincipalThrowingMockHttpExchange(String method, String requestURI) {
+            super(method, requestURI);
+        }
+
+        @Override
+        public HttpPrincipal getPrincipal() {
+            throw new RuntimeException("Glowroot should not call this directly as it may fail");
+        }
+    }
+
+}

--- a/agent/plugins/java-http-server-plugin/src/test/resources/glowroot.logback-test.xml
+++ b/agent/plugins/java-http-server-plugin/src/test/resources/glowroot.logback-test.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration>
+  <appender name="CONSOLE" class="org.glowroot.agent.shaded.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="warn">
+    <appender-ref ref="CONSOLE" />
+  </root>
+  <!-- this is needed to deal with a sporadic error message -->
+  <logger name="org.eclipse.jetty.util.thread.QueuedThreadPool" level="error" />
+</configuration>

--- a/agent/plugins/java-http-server-plugin/src/test/resources/logback-test.xml
+++ b/agent/plugins/java-http-server-plugin/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="warn">
+    <appender-ref ref="CONSOLE" />
+  </root>
+  <!-- this is needed to deal with a sporadic error message -->
+  <logger name="org.eclipse.jetty.util.thread.QueuedThreadPool" level="error" />
+</configuration>

--- a/agent/plugins/logger-plugin/pom.xml
+++ b/agent/plugins/logger-plugin/pom.xml
@@ -53,6 +53,12 @@
       <artifactId>glowroot-agent-it-harness</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
+      <exclusions>
+      	<exclusion>
+      		<artifactId>jul-to-slf4j</artifactId>
+      		<groupId>org.slf4j</groupId>
+      	</exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/agent/plugins/logger-plugin/src/main/java/org/glowroot/agent/plugin/logger/JavaLoggingAspect.java
+++ b/agent/plugins/logger-plugin/src/main/java/org/glowroot/agent/plugin/logger/JavaLoggingAspect.java
@@ -74,7 +74,7 @@ public class JavaLoggingAspect {
             }
             final String loggerName = LoggerPlugin.getAbbreviatedLoggerName(loggingEvent.getLoggerName());
             final TraceEntry traceEntry = context.startTraceEntry(MessageSupplier.create("log {}: {} - {}",
-                    level.getName(), loggerName, formattedMessage), timerName);
+                    level.getName().toLowerCase(), loggerName, formattedMessage), timerName);
             return new LogAdviceTraveler(traceEntry, lvl, formattedMessage, t);
         }
 

--- a/agent/plugins/logger-plugin/src/main/java/org/glowroot/agent/plugin/logger/JavaLoggingAspect.java
+++ b/agent/plugins/logger-plugin/src/main/java/org/glowroot/agent/plugin/logger/JavaLoggingAspect.java
@@ -15,6 +15,11 @@
  */
 package org.glowroot.agent.plugin.logger;
 
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.glowroot.agent.plugin.api.Agent;
@@ -27,51 +32,32 @@ import org.glowroot.agent.plugin.api.weaving.BindTraveler;
 import org.glowroot.agent.plugin.api.weaving.OnAfter;
 import org.glowroot.agent.plugin.api.weaving.OnBefore;
 import org.glowroot.agent.plugin.api.weaving.Pointcut;
-import org.glowroot.agent.plugin.api.weaving.Shim;
 
 public class JavaLoggingAspect {
 
-    private static final String TIMER_NAME = "logging";
-
-    // constants from org.apache.log4j.Priority
-    private static final int OFF_INT = Integer.MAX_VALUE;
-    private static final int ERROR_INT = 1000;
-    private static final int WARN_INT = 900;
-    private static final int INFO_INT = 800;
-    private static final int CONFIG_INT = 700;
-    private static final int FINE_INT = 500;
-    private static final int FINER_INT = 400;
-    private static final int FINEST_INT = 300;
-    private static final int ALL_INT = Integer.MIN_VALUE;
-    
-  @Shim("java.util.logging.LogRecord")
-  public interface LogRecord {
-
-      @Shim("java.util.logging.Level getLevel()")
-      @Nullable
-      Level glowroot$getLevel();
-
-      @Nullable
-      String getMessage();
-
-      @Nullable
-      String getLoggerName();
-
-      @Nullable
-      Throwable getThrown();
-  }
-
-    @Shim("java.util.logging.Level")
-    public interface Level {
-        int intValue();
+    private JavaLoggingAspect() {
+        throw new IllegalAccessError(); // prevent instantiation
     }
+
+    private static final String TIMER_NAME = "logging";
 
     @Pointcut(className = "java.util.logging.Logger", methodName = "log",
             methodParameterTypes = {"java.util.logging.LogRecord"},
             nestingGroup = "logging", timerName = TIMER_NAME)
-    public static class CallAppendersAdvice {
+    public static class LogAdvice {
 
-        private static final TimerName timerName = Agent.getTimerName(CallAppendersAdvice.class);
+        private LogAdvice() {
+            throw new IllegalAccessError(); // prevent instantiation
+        }
+
+        private static final TimerName timerName = Agent.getTimerName(LogAdvice.class);
+
+        private static final Formatter formatter = new Formatter() {
+            @Override
+            public String format(@Nonnull LogRecord record) {
+                return formatMessage(record);
+            }
+        };
 
         @OnBefore
         public static @Nullable LogAdviceTraveler onBefore(ThreadContext context,
@@ -79,17 +65,16 @@ public class JavaLoggingAspect {
             if (loggingEvent == null) {
                 return null;
             }
-            String formattedMessage = nullToEmpty(loggingEvent.getMessage());
-            Level level = loggingEvent.glowroot$getLevel();
-            int lvl = level == null ? 0 : level.intValue();
-            Throwable t = loggingEvent.getThrown();
-            if (LoggerPlugin.markTraceAsError(lvl >= ERROR_INT, lvl >= WARN_INT, t != null)) {
+            final String formattedMessage = formatter.format(loggingEvent);
+            final Level level = loggingEvent.getLevel(); // cannot be null
+            final int lvl = level.intValue();
+            final Throwable t = loggingEvent.getThrown();
+            if (LoggerPlugin.markTraceAsError(lvl >= Level.SEVERE.intValue(), lvl >= Level.WARNING.intValue(), t != null)) {
                 context.setTransactionError(formattedMessage, t);
             }
-            TraceEntry traceEntry;
-            String loggerName = LoggerPlugin.getAbbreviatedLoggerName(loggingEvent.getLoggerName());
-            traceEntry = context.startTraceEntry(MessageSupplier.create("log {}: {} - {}",
-                    getLevelStr(lvl), loggerName, formattedMessage), timerName);
+            final String loggerName = LoggerPlugin.getAbbreviatedLoggerName(loggingEvent.getLoggerName());
+            final TraceEntry traceEntry = context.startTraceEntry(MessageSupplier.create("log {}: {} - {}",
+                    level.getName(), loggerName, formattedMessage), timerName);
             return new LogAdviceTraveler(traceEntry, lvl, formattedMessage, t);
         }
 
@@ -98,50 +83,21 @@ public class JavaLoggingAspect {
             if (traveler == null) {
                 return;
             }
-            Throwable t = traveler.throwable;
+            final Throwable t = traveler.throwable;
             if (t != null) {
                 // intentionally not passing message since it is already the trace entry message
-                if (traveler.level >= WARN_INT) {
+                if (traveler.level >= Level.WARNING.intValue()) {
                     traveler.traceEntry.endWithError(t);
                 } else {
                     traveler.traceEntry.endWithInfo(t);
                 }
-            } else if (traveler.level >= WARN_INT) {
+            } else if (traveler.level >= Level.WARNING.intValue()) {
                 traveler.traceEntry.endWithError(traveler.formattedMessage);
             } else {
                 traveler.traceEntry.end();
             }
         }
-
-        private static String nullToEmpty(@Nullable String s) {
-            return s == null ? "" : s;
-        }
     }
-
-	private static String getLevelStr(int lvl) {
-		switch (lvl) {
-		case ALL_INT:
-			return "all";
-		case FINEST_INT:
-			return "finest";
-		case FINER_INT:
-			return "finer";
-		case FINE_INT:
-			return "fine";
-		case CONFIG_INT:
-			return "config";
-		case INFO_INT:
-			return "info";
-		case WARN_INT:
-			return "warn";
-		case ERROR_INT:
-			return "error";
-		case OFF_INT:
-			return "off";
-		default:
-			return "unknown (" + lvl + ")";
-		}
-	}
 
     private static class LogAdviceTraveler {
 

--- a/agent/plugins/logger-plugin/src/main/java/org/glowroot/agent/plugin/logger/JavaLoggingAspect.java
+++ b/agent/plugins/logger-plugin/src/main/java/org/glowroot/agent/plugin/logger/JavaLoggingAspect.java
@@ -57,7 +57,6 @@ public class JavaLoggingAspect {
       @Nullable
       String getLoggerName();
 
-      @Shim("java.lang.Throwable getThrown()")
       @Nullable
       Throwable getThrown();
   }

--- a/agent/plugins/logger-plugin/src/main/java/org/glowroot/agent/plugin/logger/JavaLoggingAspect.java
+++ b/agent/plugins/logger-plugin/src/main/java/org/glowroot/agent/plugin/logger/JavaLoggingAspect.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2014-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.logger;
+
+import javax.annotation.Nullable;
+
+import org.glowroot.agent.plugin.api.Agent;
+import org.glowroot.agent.plugin.api.MessageSupplier;
+import org.glowroot.agent.plugin.api.ThreadContext;
+import org.glowroot.agent.plugin.api.TimerName;
+import org.glowroot.agent.plugin.api.TraceEntry;
+import org.glowroot.agent.plugin.api.weaving.BindParameter;
+import org.glowroot.agent.plugin.api.weaving.BindTraveler;
+import org.glowroot.agent.plugin.api.weaving.OnAfter;
+import org.glowroot.agent.plugin.api.weaving.OnBefore;
+import org.glowroot.agent.plugin.api.weaving.Pointcut;
+import org.glowroot.agent.plugin.api.weaving.Shim;
+
+public class JavaLoggingAspect {
+
+    private static final String TIMER_NAME = "logging";
+
+    // constants from org.apache.log4j.Priority
+    private static final int OFF_INT = Integer.MAX_VALUE;
+    private static final int ERROR_INT = 1000;
+    private static final int WARN_INT = 900;
+    private static final int INFO_INT = 800;
+    private static final int CONFIG_INT = 700;
+    private static final int FINE_INT = 500;
+    private static final int FINER_INT = 400;
+    private static final int FINEST_INT = 300;
+    private static final int ALL_INT = Integer.MIN_VALUE;
+    
+  @Shim("java.util.logging.LogRecord")
+  public interface LogRecord {
+
+      @Shim("java.util.logging.Level getLevel()")
+      @Nullable
+      Level glowroot$getLevel();
+
+      @Nullable
+      String getMessage();
+
+      @Nullable
+      String getLoggerName();
+
+      @Shim("java.lang.Throwable getThrown()")
+      @Nullable
+      Throwable getThrown();
+  }
+
+    @Shim("java.util.logging.Level")
+    public interface Level {
+        int intValue();
+    }
+
+    @Pointcut(className = "java.util.logging.Logger", methodName = "log",
+            methodParameterTypes = {"java.util.logging.LogRecord"},
+            nestingGroup = "logging", timerName = TIMER_NAME)
+    public static class CallAppendersAdvice {
+
+        private static final TimerName timerName = Agent.getTimerName(CallAppendersAdvice.class);
+
+        @OnBefore
+        public static @Nullable LogAdviceTraveler onBefore(ThreadContext context,
+                @BindParameter @Nullable LogRecord loggingEvent) {
+            if (loggingEvent == null) {
+                return null;
+            }
+            String formattedMessage = nullToEmpty(loggingEvent.getMessage());
+            Level level = loggingEvent.glowroot$getLevel();
+            int lvl = level == null ? 0 : level.intValue();
+            Throwable t = loggingEvent.getThrown();
+            if (LoggerPlugin.markTraceAsError(lvl >= ERROR_INT, lvl >= WARN_INT, t != null)) {
+                context.setTransactionError(formattedMessage, t);
+            }
+            TraceEntry traceEntry;
+            String loggerName = LoggerPlugin.getAbbreviatedLoggerName(loggingEvent.getLoggerName());
+            traceEntry = context.startTraceEntry(MessageSupplier.create("log {}: {} - {}",
+                    getLevelStr(lvl), loggerName, formattedMessage), timerName);
+            return new LogAdviceTraveler(traceEntry, lvl, formattedMessage, t);
+        }
+
+        @OnAfter
+        public static void onAfter(@BindTraveler @Nullable LogAdviceTraveler traveler) {
+            if (traveler == null) {
+                return;
+            }
+            Throwable t = traveler.throwable;
+            if (t != null) {
+                // intentionally not passing message since it is already the trace entry message
+                if (traveler.level >= WARN_INT) {
+                    traveler.traceEntry.endWithError(t);
+                } else {
+                    traveler.traceEntry.endWithInfo(t);
+                }
+            } else if (traveler.level >= WARN_INT) {
+                traveler.traceEntry.endWithError(traveler.formattedMessage);
+            } else {
+                traveler.traceEntry.end();
+            }
+        }
+
+        private static String nullToEmpty(@Nullable String s) {
+            return s == null ? "" : s;
+        }
+    }
+
+	private static String getLevelStr(int lvl) {
+		switch (lvl) {
+		case ALL_INT:
+			return "all";
+		case FINEST_INT:
+			return "finest";
+		case FINER_INT:
+			return "finer";
+		case FINE_INT:
+			return "fine";
+		case CONFIG_INT:
+			return "config";
+		case INFO_INT:
+			return "info";
+		case WARN_INT:
+			return "warn";
+		case ERROR_INT:
+			return "error";
+		case OFF_INT:
+			return "off";
+		default:
+			return "unknown (" + lvl + ")";
+		}
+	}
+
+    private static class LogAdviceTraveler {
+
+        private final TraceEntry traceEntry;
+        private final int level;
+        private final String formattedMessage;
+        private final @Nullable Throwable throwable;
+
+        private LogAdviceTraveler(TraceEntry traceEntry, int level, String formattedMessage,
+                @Nullable Throwable throwable) {
+            this.traceEntry = traceEntry;
+            this.level = level;
+            this.formattedMessage = formattedMessage;
+            this.throwable = throwable;
+        }
+    }
+}

--- a/agent/plugins/logger-plugin/src/main/resources/META-INF/glowroot.plugin.json
+++ b/agent/plugins/logger-plugin/src/main/resources/META-INF/glowroot.plugin.json
@@ -38,6 +38,7 @@
   "aspects": [
     "org.glowroot.agent.plugin.logger.LogbackAspect",
     "org.glowroot.agent.plugin.logger.Log4jAspect",
-    "org.glowroot.agent.plugin.logger.Log4j2xAspect"
+    "org.glowroot.agent.plugin.logger.Log4j2xAspect",
+    "org.glowroot.agent.plugin.logger.JavaLoggingAspect"
   ]
 }

--- a/agent/plugins/logger-plugin/src/test/java/org/glowroot/agent/plugin/logger/JavaLoggingIT.java
+++ b/agent/plugins/logger-plugin/src/test/java/org/glowroot/agent/plugin/logger/JavaLoggingIT.java
@@ -1,0 +1,542 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Iterator;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.glowroot.agent.it.harness.AppUnderTest;
+import org.glowroot.agent.it.harness.Container;
+import org.glowroot.agent.it.harness.Containers;
+import org.glowroot.agent.it.harness.TransactionMarker;
+import org.glowroot.wire.api.model.TraceOuterClass.Trace;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class JavaLoggingIT {
+
+    private static final String PLUGIN_ID = "logger";
+
+    private static Container container;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Assume.assumeFalse(isBridged());
+        Assume.assumeTrue(isShaded());
+        Assume.assumeTrue("javaagent".equals(System.getProperty("glowroot.it.harness")));
+        container = Containers.create();
+    }
+
+    private static boolean isBridged() {
+        try {
+            Class.forName("org.slf4j.bridge.SLF4JBridgeHandler");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    private static boolean isShaded() {
+        try {
+            Class.forName("org.glowroot.agent.shaded.slf4j.Logger");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // need null check in case assumption is false in setUp()
+        if (container != null) {
+            container.close();
+        }
+    }
+
+    @After
+    public void afterEachTest() throws Exception {
+        container.checkAndReset();
+    }
+
+    @Test
+    public void testLog() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID,
+                "traceErrorOnErrorWithoutThrowable", true);
+
+        // when
+        Trace trace = container.execute(ShouldLog.class);
+
+        // then
+        assertThat(trace.getHeader().getError().getMessage()).isEqualTo("efg");
+
+        Iterator<Trace.Entry> i = trace.getEntryList().iterator();
+
+        Trace.Entry entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log info: o.g.a.p.l.JavaLoggingIT$ShouldLog - cde");
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log warning: o.g.a.p.l.JavaLoggingIT$ShouldLog - def");
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log severe: o.g.a.p.l.JavaLoggingIT$ShouldLog - efg");
+
+        assertThat(i.hasNext()).isFalse();
+    }
+
+    @Test
+    public void testLogWithThrowable() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID,
+                "traceErrorOnErrorWithoutThrowable", true);
+
+        // when
+        Trace trace = container.execute(ShouldLogWithThrowable.class);
+
+        // then
+        assertThat(trace.getHeader().getError().getMessage()).isEqualTo("efg_");
+
+        Iterator<Trace.Entry> i = trace.getEntryList().iterator();
+
+        Trace.Entry entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log info: o.g.a.p.l.JavaLoggingIT$ShouldLogWithThrowable - cde_");
+
+        assertThat(entry.getError().getMessage()).isEqualTo("345");
+        assertThat(
+                entry.getError().getException().getStackTraceElementList().get(0).getMethodName())
+                        .isEqualTo("transactionMarker");
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log warning: o.g.a.p.l.JavaLoggingIT$ShouldLogWithThrowable - def_");
+
+        assertThat(entry.getError().getMessage()).isEqualTo("456");
+        assertThat(
+                entry.getError().getException().getStackTraceElementList().get(0).getMethodName())
+                        .isEqualTo("transactionMarker");
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log severe: o.g.a.p.l.JavaLoggingIT$ShouldLogWithThrowable - efg_");
+
+        assertThat(entry.getError().getMessage()).isEqualTo("567");
+        assertThat(
+                entry.getError().getException().getStackTraceElementList().get(0).getMethodName())
+                        .isEqualTo("transactionMarker");
+
+        assertThat(i.hasNext()).isFalse();
+    }
+
+    @Test
+    public void testLogWithNullThrowable() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID,
+                "traceErrorOnErrorWithoutThrowable", true);
+
+        // when
+        Trace trace = container.execute(ShouldLogWithNullThrowable.class);
+
+        // then
+        assertThat(trace.getHeader().getError().getMessage()).isEqualTo("efg_");
+
+        Iterator<Trace.Entry> i = trace.getEntryList().iterator();
+
+        Trace.Entry entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log info: o.g.a.p.l.JavaLoggingIT$ShouldLogWithNullThrowable - cde_");
+
+        assertThat(entry.getError().getMessage()).isEmpty(); // populated only if level > WARNING
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log warning: o.g.a.p.l.JavaLoggingIT$ShouldLogWithNullThrowable - def_");
+
+        assertThat(entry.getError().getMessage()).isEqualTo("def_");
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log severe: o.g.a.p.l.JavaLoggingIT$ShouldLogWithNullThrowable - efg_");
+
+        assertThat(entry.getError().getMessage()).isEqualTo("efg_");
+
+        assertThat(i.hasNext()).isFalse();
+    }
+
+    @Test
+    public void testLogWithPriority() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID,
+                "traceErrorOnErrorWithoutThrowable", true);
+
+        // when
+        Trace trace = container.execute(ShouldLogWithPriority.class);
+
+        // then
+        assertThat(trace.getHeader().getError().getMessage()).isEqualTo("efg__");
+
+        Iterator<Trace.Entry> i = trace.getEntryList().iterator();
+
+        Trace.Entry entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log info: o.g.a.p.l.JavaLoggingIT$ShouldLogWithPriority - cde__");
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log warning: o.g.a.p.l.JavaLoggingIT$ShouldLogWithPriority - def__");
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log severe: o.g.a.p.l.JavaLoggingIT$ShouldLogWithPriority - efg__");
+
+        assertThat(i.hasNext()).isFalse();
+    }
+
+    @Test
+    public void testLogWithPriorityAndThrowable() throws Exception {
+        // when
+        Trace trace = container.execute(ShouldLogWithPriorityAndThrowable.class);
+
+        // then
+        assertThat(trace.getHeader().getError().getMessage()).isEqualTo("efg___");
+
+        Iterator<Trace.Entry> i = trace.getEntryList().iterator();
+
+        Trace.Entry entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage()).isEqualTo(
+                "log info: o.g.a.p.l.JavaLoggingIT$ShouldLogWithPriorityAndThrowable - cde___");
+
+        assertThat(entry.getError().getMessage()).isEqualTo("345_");
+        assertThat(
+                entry.getError().getException().getStackTraceElementList().get(0).getMethodName())
+                        .isEqualTo("transactionMarker");
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage()).isEqualTo(
+                "log warning: o.g.a.p.l.JavaLoggingIT$ShouldLogWithPriorityAndThrowable - def___");
+
+        assertThat(entry.getError().getMessage()).isEqualTo("456_");
+        assertThat(
+                entry.getError().getException().getStackTraceElementList().get(0).getMethodName())
+                        .isEqualTo("transactionMarker");
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage()).isEqualTo(
+                "log severe: o.g.a.p.l.JavaLoggingIT$ShouldLogWithPriorityAndThrowable - efg___");
+
+        assertThat(entry.getError().getMessage()).isEqualTo("567_");
+        assertThat(
+                entry.getError().getException().getStackTraceElementList().get(0).getMethodName())
+                        .isEqualTo("transactionMarker");
+
+        assertThat(i.hasNext()).isFalse();
+    }
+
+    @Test
+    public void testLogWithPriorityAndNullThrowable() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID,
+                "traceErrorOnErrorWithoutThrowable", true);
+
+        // when
+        Trace trace = container.execute(ShouldLogWithPriorityAndNullThrowable.class);
+
+        // then
+        assertThat(trace.getHeader().getError().getMessage()).isEqualTo("efg___null");
+
+        Iterator<Trace.Entry> i = trace.getEntryList().iterator();
+
+        Trace.Entry entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage()).isEqualTo(
+                "log info: o.g.a.p.l.JavaLoggingIT$ShouldLogWithPriorityAndNullThrowable - cde___null");
+
+        assertThat(entry.getError().getMessage()).isEmpty(); // populated only if level > WARNING
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage()).isEqualTo(
+                "log warning: o.g.a.p.l.JavaLoggingIT$ShouldLogWithPriorityAndNullThrowable - def___null");
+
+        assertThat(entry.getError().getMessage()).isEqualTo("def___null");
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage()).isEqualTo(
+                "log severe: o.g.a.p.l.JavaLoggingIT$ShouldLogWithPriorityAndNullThrowable - efg___null");
+
+        assertThat(entry.getError().getMessage()).isEqualTo("efg___null");
+
+        assertThat(i.hasNext()).isFalse();
+    }
+
+    @Test
+    public void testLogWithParameters() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID,
+                "traceErrorOnErrorWithoutThrowable", true);
+
+        // when
+        Trace trace = container.execute(ShouldLogWithParameters.class);
+
+        // then
+        assertThat(trace.getHeader().getError().getMessage()).isEqualTo("ghi_78_89");
+
+        Iterator<Trace.Entry> i = trace.getEntryList().iterator();
+
+        Trace.Entry entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log info: o.g.a.p.l.JavaLoggingIT$ShouldLogWithParameters - efg_56_67");
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log warning: o.g.a.p.l.JavaLoggingIT$ShouldLogWithParameters - fgh_67_78");
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log severe: o.g.a.p.l.JavaLoggingIT$ShouldLogWithParameters - ghi_78_89");
+
+        assertThat(i.hasNext()).isFalse();
+    }
+
+    @Test
+    public void testLocalizedLogWithParameters() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID,
+                "traceErrorOnErrorWithoutThrowable", true);
+
+        // when
+        Trace trace = container.execute(ShouldLocalizedLogWithParameters.class);
+
+        // then
+        assertThat(trace.getHeader().getError().getMessage()).isEqualTo("abc_78_89");
+
+        Iterator<Trace.Entry> i = trace.getEntryList().iterator();
+
+        Trace.Entry entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log info: o.g.a.p.l.JavaLoggingIT$ShouldLocalizedLogWithParameters - abc_56_67");
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log warning: o.g.a.p.l.JavaLoggingIT$ShouldLocalizedLogWithParameters - xyz_78_67");
+
+        entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("log severe: o.g.a.p.l.JavaLoggingIT$ShouldLocalizedLogWithParameters - abc_78_89");
+
+        assertThat(i.hasNext()).isFalse();
+    }
+    
+    public static class ShouldLog implements AppUnderTest, TransactionMarker {
+        private static final Logger logger = Logger.getLogger(ShouldLog.class.getName());
+        @Override
+        public void executeApp() {
+            transactionMarker();
+        }
+        @Override
+        public void transactionMarker() {
+            logger.finest("wxy");
+            logger.finer("xyz");
+            logger.fine("abc");
+            logger.config("bcd");
+            logger.info("cde");
+            logger.warning("def");
+            logger.severe("efg");
+        }
+    }
+
+    public static class ShouldLogWithThrowable implements AppUnderTest, TransactionMarker {
+        private static final Logger logger = Logger.getLogger(ShouldLogWithThrowable.class.getName());
+        @Override
+        public void executeApp() {
+            transactionMarker();
+        }
+        @Override
+        public void transactionMarker() {
+            logger.log(Level.FINEST, "wxy_", new IllegalStateException("678"));
+            logger.log(Level.FINER, "xyz_", new IllegalStateException("789"));
+            logger.log(Level.FINE, "abc_", new IllegalStateException("123"));
+            logger.log(Level.CONFIG, "bcd_", new IllegalStateException("234"));
+            logger.log(Level.INFO, "cde_", new IllegalStateException("345"));
+            logger.log(Level.WARNING, "def_", new IllegalStateException("456"));
+            logger.log(Level.SEVERE, "efg_", new IllegalStateException("567"));
+        }
+    }
+
+    public static class ShouldLogWithNullThrowable implements AppUnderTest, TransactionMarker {
+        private static final Logger logger = Logger.getLogger(ShouldLogWithNullThrowable.class.getName());
+        @Override
+        public void executeApp() {
+            transactionMarker();
+        }
+        @Override
+        public void transactionMarker() {
+            logger.log(Level.FINEST, "wxy_", (Throwable) null);
+            logger.log(Level.FINER, "xyz_", (Throwable) null);
+            logger.log(Level.FINE, "abc_", (Throwable) null);
+            logger.log(Level.CONFIG, "bcd_", (Throwable) null);
+            logger.log(Level.INFO, "cde_", (Throwable) null);
+            logger.log(Level.WARNING, "def_", (Throwable) null);
+            logger.log(Level.SEVERE, "efg_", (Throwable) null);
+        }
+    }
+
+    public static class ShouldLogWithPriority implements AppUnderTest, TransactionMarker {
+        private static final Logger logger = Logger.getLogger(ShouldLogWithPriority.class.getName());
+        @Override
+        public void executeApp() {
+            transactionMarker();
+        }
+        @Override
+        public void transactionMarker() {
+            try {
+                logger.log(null, "abc__");
+            } catch (NullPointerException e) {
+                // re-throw if it does not originate from log4j
+                if (!e.getStackTrace()[0].getClassName().startsWith("java.util.logging.")) {
+                    throw e;
+                }
+            }
+            logger.log(Level.FINEST, "vwx__");
+            logger.log(Level.FINER, "wxy__");
+            logger.log(Level.FINE, "xyz__");
+            logger.log(Level.CONFIG, "bcd__");
+            logger.log(Level.INFO, "cde__");
+            logger.log(Level.WARNING, "def__");
+            logger.log(Level.SEVERE, "efg__");
+        }
+    }
+
+    public static class ShouldLogWithPriorityAndThrowable
+            implements AppUnderTest, TransactionMarker {
+        private static final Logger logger =
+                Logger.getLogger(ShouldLogWithPriorityAndThrowable.class.getName());
+        @Override
+        public void executeApp() {
+            transactionMarker();
+        }
+        @Override
+        public void transactionMarker() {
+            try {
+                logger.log(null, "abc___", new IllegalStateException("123_"));
+            } catch (NullPointerException e) {
+                // re-throw if it does not originate from log4j
+                if (!e.getStackTrace()[0].getClassName().startsWith("java.util.logging.")) {
+                    throw e;
+                }
+            }
+            logger.log(Level.FINEST, "vwx___", new IllegalStateException("111_"));
+            logger.log(Level.FINER, "wxy___", new IllegalStateException("222_"));
+            logger.log(Level.FINE, "xwy___", new IllegalStateException("333_"));
+            logger.log(Level.CONFIG, "bcd___", new IllegalStateException("234_"));
+            logger.log(Level.INFO, "cde___", new IllegalStateException("345_"));
+            logger.log(Level.WARNING, "def___", new IllegalStateException("456_"));
+            logger.log(Level.SEVERE, "efg___", new IllegalStateException("567_"));
+        }
+    }
+
+    public static class ShouldLogWithPriorityAndNullThrowable
+            implements AppUnderTest, TransactionMarker {
+        private static final Logger logger =
+                Logger.getLogger(ShouldLogWithPriorityAndNullThrowable.class.getName());
+        @Override
+        public void executeApp() {
+            transactionMarker();
+        }
+        @Override
+        public void transactionMarker() {
+            logger.log(Level.FINEST, "vwx___null", (Throwable) null);
+            logger.log(Level.FINER, "wxy___null", (Throwable) null);
+            logger.log(Level.FINE, "xyz___null", (Throwable) null);
+            logger.log(Level.CONFIG, "bcd___null", (Throwable) null);
+            logger.log(Level.INFO, "cde___null", (Throwable) null);
+            logger.log(Level.WARNING, "def___null", (Throwable) null);
+            logger.log(Level.SEVERE, "efg___null", (Throwable) null);
+        }
+    }
+
+    public static class ShouldLogWithParameters implements AppUnderTest, TransactionMarker {
+        private static final Logger logger = Logger.getLogger(ShouldLogWithParameters.class.getName());
+
+        @Override
+        public void executeApp() {
+            transactionMarker();
+        }
+
+        @Override
+        public void transactionMarker() {
+            logger.log(Level.FINEST, "abc_{0}_{1}", new Object[] { 12, 23 });
+            logger.log(Level.FINER, "bcd_{0}_{1}", new Object[] { 23, 34 });
+            logger.log(Level.FINE, "cde_{0}_{1}", new Object[] { 34, 45 });
+            logger.log(Level.CONFIG, "def_{0}_{1}", new Object[] { 45, 56 });
+            logger.log(Level.INFO, "efg_{0}_{1}", new Object[] { 56, 67 });
+            logger.log(Level.WARNING, "fgh_{0}_{1}", new Object[] { 67, 78 });
+            logger.log(Level.SEVERE, "ghi_{0}_{1}", new Object[] { 78, 89 });
+        }
+    }
+
+    public static class ShouldLocalizedLogWithParameters implements AppUnderTest, TransactionMarker {
+        private static final Logger logger = Logger.getLogger(ShouldLocalizedLogWithParameters.class.getName(), "julmsgs");
+
+        @Override
+        public void executeApp() {
+            transactionMarker();
+        }
+
+        @Override
+        public void transactionMarker() {
+            logger.log(Level.FINEST, "log.message.key1", new Object[] { 12, 23 });
+            logger.log(Level.FINER, "log.message.key2", new Object[] { 23, 34 });
+            logger.log(Level.FINE, "log.message.key1", new Object[] { 34, 45 });
+            logger.log(Level.CONFIG, "log.message.key2", new Object[] { 45, 56 });
+            logger.log(Level.INFO, "log.message.key1", new Object[] { 56, 67 });
+            logger.log(Level.WARNING, "log.message.key2", new Object[] { 67, 78 });
+            logger.log(Level.SEVERE, "log.message.key1", new Object[] { 78, 89 });
+        }
+    }
+
+}

--- a/agent/plugins/logger-plugin/src/test/resources/julmsgs.properties
+++ b/agent/plugins/logger-plugin/src/test/resources/julmsgs.properties
@@ -1,0 +1,2 @@
+log.message.key1=abc_{0}_{1}
+log.message.key2=xyz_{1}_{0}

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <module>agent/plugins/grails-plugin</module>
     <module>agent/plugins/hibernate-plugin</module>
     <module>agent/plugins/http-client-plugin</module>
+    <module>agent/plugins/java-http-server-plugin</module>
     <module>agent/plugins/jaxrs-plugin</module>
     <module>agent/plugins/jdbc-plugin</module>
     <module>agent/plugins/jms-plugin</module>


### PR DESCRIPTION
Hi @trask, this PR includes:
* Logger plugin: added support for **java.util.logging**.
* New **Java HTTP Server plugin** that enable support for the Java HTTP Server bundled with JRE since version 6. This plugin is similar to the Servlet Plugin but it's simpler because the Java HTTP Server doesn't have native support for sessions, async requests and parameters. I'm already using this new plugin on a real scenario. Feel free to rename the plugin if you don't like the name I chose; I took the name from the title of the [Oracle documentation page](https://docs.oracle.com/javase/8/docs/jre/api/net/httpserver/spec/index.html).
Tests are included.

Thank you a lot for your great work.