### PR TITLE
Java HTTP Server plugin: fixed bug that caused masking of response headers.

### DIFF
--- a/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/RequestHeaderIT.java
+++ b/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/RequestHeaderIT.java
@@ -109,6 +109,25 @@ public class RequestHeaderIT {
         assertThat(requestHeaders.get("Three")).isNull();
     }
 
+    @Test
+    public void testMaskRequestHeaders() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID, "captureRequestHeaders",
+                "*");
+        container.getConfigService().setPluginProperty(PLUGIN_ID, "maskRequestHeaders",
+                "content-Len*");
+
+        // when
+        Trace trace = container.execute(SetStandardRequestHeaders.class, "Web");
+
+        // then
+        Map<String, Object> requestHeaders =
+                ResponseHeaderIT.getDetailMap(trace, "Request headers");
+        assertThat(requestHeaders.get("Content-type")).isEqualTo("text/plain;charset=UTF-8");
+        assertThat(requestHeaders.get("Content-length")).isEqualTo("****");
+        assertThat(requestHeaders.get("Extra")).isEqualTo("abc");
+    }
+
     public static class SetStandardRequestHeaders extends TestHandler {
         @Override
         protected void before(HttpExchange exchange) {

--- a/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/ResponseHeaderIT.java
+++ b/agent/plugins/java-http-server-plugin/src/test/java/org/glowroot/agent/plugin/javahttpserver/ResponseHeaderIT.java
@@ -165,6 +165,24 @@ public class ResponseHeaderIT {
         // basically just testing that it should not generate any errors
     }
 
+    @Test
+    public void testDontMaskResponseHeaders() throws Exception {
+        // given
+        container.getConfigService().setPluginProperty(PLUGIN_ID, "captureResponseHeaders",
+                "content*");
+        container.getConfigService().setPluginProperty(PLUGIN_ID, "maskRequestHeaders",
+                "content-Len*");
+
+        // when
+        Trace trace = container.execute(SetStandardResponseHeadersLowercase.class, "Web");
+
+        // then
+        Map<String, Object> responseHeaders = getResponseHeaders(trace);
+        assertThat(responseHeaders.get("Content-type")).isEqualTo("text/plain;charset=UTF-8");
+        assertThat(responseHeaders.get("Content-length")).isEqualTo("1");
+        assertThat(responseHeaders.get("Extra")).isNull();
+    }
+
     static @Nullable Map<String, Object> getDetailMap(Trace trace, String name) {
         List<Trace.DetailEntry> details = trace.getHeader().getDetailEntryList();
         Trace.DetailEntry found = null;


### PR DESCRIPTION
- Added `ImmutableList<Pattern> maskPatterns` argument to `DetailCapture.captureHeaders(...)` method signature.
- Added tests.