### PR TITLE
glowroot-central: Change user in docker image to avoid image run as root

### DIFF
--- a/central/Dockerfile
+++ b/central/Dockerfile
@@ -4,13 +4,17 @@ COPY target/glowroot-central-*.zip /tmp/glowroot-central.zip
 
 RUN unzip -d /usr/share /tmp/glowroot-central.zip \
     && rm /tmp/glowroot-central.zip \
-    && sed -i 's/^cassandra.contactPoints=$/cassandra.contactPoints=cassandra/' /usr/share/glowroot-central/glowroot-central.properties
+    && sed -i 's/^cassandra.contactPoints=$/cassandra.contactPoints=cassandra/' /usr/share/glowroot-central/glowroot-central.properties \
+    && groupadd -r glowroot \
+    && useradd --no-log-init -r -g glowroot glowroot
 
 EXPOSE 4000 8181
 
 COPY docker-entrypoint.sh /usr/local/bin/
 
 WORKDIR /usr/share/glowroot-central
+
+USER glowroot:glowroot
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 


### PR DESCRIPTION
glowroot-central: Docker image: create group/user glowroot and change user to glowroot:glowroot to avoid running image as root (otherwise, image cannot be used e.g. on OpenShift).