### PR TITLE
Fix link to benchmarks project on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Browser-based integration tests are run using WebDriver.  By default they run ag
 
 ## Microbenchmarks
 
-Microbenchmarks are written using the excellent [JMH](http://openjdk.java.net/projects/code-tools/jmh/) benchmark harness. The microbenchmarks can be built and run under [agent-parent/benchmarks](agent-parent/benchmarks):
+Microbenchmarks are written using the excellent [JMH](http://openjdk.java.net/projects/code-tools/jmh/) benchmark harness. The microbenchmarks can be built and run under [agent/benchmarks](agent/benchmarks):
 
     mvn clean package
     java -jar target/benchmarks.jar -jvmArgs -javaagent:path/to/glowroot.jar


### PR DESCRIPTION
I've saw a small mistake on `README.md` file when a link to agent benchmarks doesn't worked.

Congrats for your impressive work!

Regards,
Bruno