### PR TITLE
Add GLOWROOT_OPTS to configure JVM, default to use cgroups limits

### DIFF
--- a/central/Dockerfile
+++ b/central/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8
 
-ENV GLOWROOT_OPTS="-XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+ENV GLOWROOT_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
 
 COPY target/glowroot-central-*.zip /tmp/glowroot-central.zip
 

--- a/central/Dockerfile
+++ b/central/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:8
 
+ENV GLOWROOT_OPTS="-XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+
 COPY target/glowroot-central-*.zip /tmp/glowroot-central.zip
 
 RUN unzip -d /usr/share /tmp/glowroot-central.zip \
@@ -13,6 +15,7 @@ RUN unzip -d /usr/share /tmp/glowroot-central.zip \
 EXPOSE 4000 8181
 
 COPY docker-entrypoint.sh /usr/local/bin/
+COPY start-glowroot.sh /usr/local/bin/
 
 WORKDIR /usr/share/glowroot-central
 
@@ -20,4 +23,5 @@ USER glowroot:glowroot
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-CMD ["java", "-jar", "glowroot-central.jar"]
+CMD ["/usr/local/bin/start-glowroot.sh"]
+

--- a/central/start-glowroot.sh
+++ b/central/start-glowroot.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 # 
 
-java $GLOWROOT_OPTS -jar glowroot-central.jar
+exec java $GLOWROOT_OPTS -jar glowroot-central.jar
 

--- a/central/start-glowroot.sh
+++ b/central/start-glowroot.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# 
+
+java $GLOWROOT_OPTS -jar glowroot-central.jar
+


### PR DESCRIPTION
Glowroot Central start without any JVM options.
Consequence Java will allocate 25% of physical memory, ie 4GB on a 16GB machine.
Since Java 8u131, we could ask JVM to use cgroups limits instead of physical to calculate default memory sizing, this is the perfect way to tune JVM on Docker but Kubernetes too.

See https://blog.csanchez.org/2017/05/31/running-a-jvm-in-a-container-without-getting-killed/

As a bonus, GLOWROOT_OPS is now exposed and if set, user could finely tune JVM options ie 

    docker run -e "GLOWROOT_OPTS=-Xmx256m -Xms256m" glowroot/glowroot