### PR TITLE
Change EJB remote transaction type to Web

### DIFF
--- a/agent/core/src/main/java/org/glowroot/agent/weaving/ClassAnalyzer.java
+++ b/agent/core/src/main/java/org/glowroot/agent/weaving/ClassAnalyzer.java
@@ -605,7 +605,7 @@ class ClassAnalyzer {
                     .methodName("*")
                     .addMethodParameterTypes("..")
                     .captureKind(CaptureKind.TRANSACTION)
-                    .transactionType("Background")
+                    .transactionType("Web")
                     .transactionNameTemplate("EJB remote: " + shortClassName + "#{{methodName}}")
                     .traceEntryMessageTemplate(
                             "EJB remote: " + entry.getValue() + ".{{methodName}}()")

--- a/agent/plugins/ejb-plugin/src/test/java/org/glowroot/agent/plugin/ejb/EjbRemoteIT.java
+++ b/agent/plugins/ejb-plugin/src/test/java/org/glowroot/agent/plugin/ejb/EjbRemoteIT.java
@@ -55,7 +55,7 @@ public class EjbRemoteIT {
     public void shouldCaptureARemoteBeanOne() throws Exception {
         Trace trace = container.execute(ExecuteARemoteBeanOne.class);
         Trace.Header header = trace.getHeader();
-        assertThat(header.getTransactionType()).isEqualTo("Background");
+        assertThat(header.getTransactionType()).isEqualTo("Web");
         assertThat(header.getTransactionName()).isEqualTo("EJB remote: ARemoteOne#one");
         assertThat(header.getHeadline()).isEqualTo(
                 "EJB remote: org.glowroot.agent.plugin.ejb.EjbRemoteIT$ARemoteOne.one()");
@@ -65,7 +65,7 @@ public class EjbRemoteIT {
     public void shouldCaptureARemoteBeanTwo() throws Exception {
         Trace trace = container.execute(ExecuteARemoteBeanTwo.class);
         Trace.Header header = trace.getHeader();
-        assertThat(header.getTransactionType()).isEqualTo("Background");
+        assertThat(header.getTransactionType()).isEqualTo("Web");
         assertThat(header.getTransactionName()).isEqualTo("EJB remote: ARemoteTwo#two");
         assertThat(header.getHeadline()).isEqualTo(
                 "EJB remote: org.glowroot.agent.plugin.ejb.EjbRemoteIT$ARemoteTwo.two()");
@@ -75,7 +75,7 @@ public class EjbRemoteIT {
     public void shouldCaptureA2RemoteBeanOne() throws Exception {
         Trace trace = container.execute(ExecuteA2RemoteBeanOne.class);
         Trace.Header header = trace.getHeader();
-        assertThat(header.getTransactionType()).isEqualTo("Background");
+        assertThat(header.getTransactionType()).isEqualTo("Web");
         assertThat(header.getTransactionName()).isEqualTo("EJB remote: ARemoteOne#one");
         assertThat(header.getHeadline()).isEqualTo(
                 "EJB remote: org.glowroot.agent.plugin.ejb.EjbRemoteIT$ARemoteOne.one()");
@@ -85,7 +85,7 @@ public class EjbRemoteIT {
     public void shouldCaptureA2RemoteBeanTwo() throws Exception {
         Trace trace = container.execute(ExecuteA2RemoteBeanTwo.class);
         Trace.Header header = trace.getHeader();
-        assertThat(header.getTransactionType()).isEqualTo("Background");
+        assertThat(header.getTransactionType()).isEqualTo("Web");
         assertThat(header.getTransactionName()).isEqualTo("EJB remote: ARemoteTwo#two");
         assertThat(header.getHeadline()).isEqualTo(
                 "EJB remote: org.glowroot.agent.plugin.ejb.EjbRemoteIT$ARemoteTwo.two()");
@@ -95,7 +95,7 @@ public class EjbRemoteIT {
     public void shouldCaptureA3RemoteBeanOne() throws Exception {
         Trace trace = container.execute(ExecuteA3RemoteBeanOne.class);
         Trace.Header header = trace.getHeader();
-        assertThat(header.getTransactionType()).isEqualTo("Background");
+        assertThat(header.getTransactionType()).isEqualTo("Web");
         assertThat(header.getTransactionName()).isEqualTo("EJB remote: ARemoteOne#one");
         assertThat(header.getHeadline()).isEqualTo(
                 "EJB remote: org.glowroot.agent.plugin.ejb.EjbRemoteIT$ARemoteOne.one()");
@@ -105,7 +105,7 @@ public class EjbRemoteIT {
     public void shouldCaptureA3RemoteBeanTwo() throws Exception {
         Trace trace = container.execute(ExecuteA3RemoteBeanTwo.class);
         Trace.Header header = trace.getHeader();
-        assertThat(header.getTransactionType()).isEqualTo("Background");
+        assertThat(header.getTransactionType()).isEqualTo("Web");
         assertThat(header.getTransactionName()).isEqualTo("EJB remote: ARemoteTwo#two");
         assertThat(header.getHeadline()).isEqualTo(
                 "EJB remote: org.glowroot.agent.plugin.ejb.EjbRemoteIT$ARemoteTwo.two()");
@@ -115,7 +115,7 @@ public class EjbRemoteIT {
     public void shouldCaptureBRemoteBeanOne() throws Exception {
         Trace trace = container.execute(ExecuteBRemoteBeanOne.class);
         Trace.Header header = trace.getHeader();
-        assertThat(header.getTransactionType()).isEqualTo("Background");
+        assertThat(header.getTransactionType()).isEqualTo("Web");
         assertThat(header.getTransactionName()).isEqualTo("EJB remote: BRemoteOne#one");
         assertThat(header.getHeadline()).isEqualTo(
                 "EJB remote: org.glowroot.agent.plugin.ejb.EjbRemoteIT$BRemoteOne.one()");
@@ -125,7 +125,7 @@ public class EjbRemoteIT {
     public void shouldCaptureBRemoteBeanTwo() throws Exception {
         Trace trace = container.execute(ExecuteBRemoteBeanTwo.class);
         Trace.Header header = trace.getHeader();
-        assertThat(header.getTransactionType()).isEqualTo("Background");
+        assertThat(header.getTransactionType()).isEqualTo("Web");
         assertThat(header.getTransactionName()).isEqualTo("EJB remote: BRemoteTwo#two");
         assertThat(header.getHeadline()).isEqualTo(
                 "EJB remote: org.glowroot.agent.plugin.ejb.EjbRemoteIT$BRemoteTwo.two()");
@@ -135,7 +135,7 @@ public class EjbRemoteIT {
     public void shouldCaptureB2RemoteBeanOne() throws Exception {
         Trace trace = container.execute(ExecuteB2RemoteBeanOne.class);
         Trace.Header header = trace.getHeader();
-        assertThat(header.getTransactionType()).isEqualTo("Background");
+        assertThat(header.getTransactionType()).isEqualTo("Web");
         assertThat(header.getTransactionName()).isEqualTo("EJB remote: BRemoteOne#one");
         assertThat(header.getHeadline()).isEqualTo(
                 "EJB remote: org.glowroot.agent.plugin.ejb.EjbRemoteIT$BRemoteOne.one()");
@@ -145,7 +145,7 @@ public class EjbRemoteIT {
     public void shouldCaptureB2RemoteBeanTwo() throws Exception {
         Trace trace = container.execute(ExecuteB2RemoteBeanTwo.class);
         Trace.Header header = trace.getHeader();
-        assertThat(header.getTransactionType()).isEqualTo("Background");
+        assertThat(header.getTransactionType()).isEqualTo("Web");
         assertThat(header.getTransactionName()).isEqualTo("EJB remote: BRemoteTwo#two");
         assertThat(header.getHeadline()).isEqualTo(
                 "EJB remote: org.glowroot.agent.plugin.ejb.EjbRemoteIT$BRemoteTwo.two()");
@@ -155,7 +155,7 @@ public class EjbRemoteIT {
     public void shouldCaptureB3RemoteBeanOne() throws Exception {
         Trace trace = container.execute(ExecuteB3RemoteBeanOne.class);
         Trace.Header header = trace.getHeader();
-        assertThat(header.getTransactionType()).isEqualTo("Background");
+        assertThat(header.getTransactionType()).isEqualTo("Web");
         assertThat(header.getTransactionName()).isEqualTo("EJB remote: BRemoteOne#one");
         assertThat(header.getHeadline()).isEqualTo(
                 "EJB remote: org.glowroot.agent.plugin.ejb.EjbRemoteIT$BRemoteOne.one()");
@@ -163,9 +163,9 @@ public class EjbRemoteIT {
 
     @Test
     public void shouldCaptureB3RemoteBeanTwo() throws Exception {
-        Trace trace = container.execute(ExecuteB3RemoteBeanTwo.class);
+        Trace trace = container.execute(ExecuteB3RemoteBeanTwo. class);
         Trace.Header header = trace.getHeader();
-        assertThat(header.getTransactionType()).isEqualTo("Background");
+        assertThat(header.getTransactionType()).isEqualTo("Web");
         assertThat(header.getTransactionName()).isEqualTo("EJB remote: BRemoteTwo#two");
         assertThat(header.getHeadline()).isEqualTo(
                 "EJB remote: org.glowroot.agent.plugin.ejb.EjbRemoteIT$BRemoteTwo.two()");
@@ -175,7 +175,7 @@ public class EjbRemoteIT {
     public void shouldCaptureCRemoteSessionBeanOne() throws Exception {
         Trace trace = container.execute(ExecuteCRemoteSessionBeanOne.class);
         Trace.Header header = trace.getHeader();
-        assertThat(header.getTransactionType()).isEqualTo("Background");
+        assertThat(header.getTransactionType()).isEqualTo("Web");
         assertThat(header.getTransactionName()).isEqualTo("EJB remote: CRemoteSessionOne#one");
         assertThat(header.getHeadline()).isEqualTo(
                 "EJB remote: org.glowroot.agent.plugin.ejb.EjbRemoteIT$CRemoteSessionOne.one()");


### PR DESCRIPTION
Hi @trask ,

Considering rest api calls are "Web" transactions, I think it's better to mark EJB remote calls as "Web" transactions