### PR TITLE
Add RabbitListener support for spring-plugin

### DIFF
--- a/agent/plugins/spring-plugin/src/main/resources/META-INF/glowroot.plugin.json
+++ b/agent/plugins/spring-plugin/src/main/resources/META-INF/glowroot.plugin.json
@@ -47,6 +47,18 @@
       "transactionNameTemplate": "Spring scheduled: {{this.class.simpleName}}#{{methodName}}",
       "traceEntryMessageTemplate": "Spring scheduled: {{this.class.name}}.{{methodName}}()",
       "timerName": "spring scheduled"
+    },
+    {
+      "classAnnotation": "org.springframework.stereotype.Component|org.springframework.stereotype.Service",
+      "methodAnnotation": "org.springframework.amqp.rabbit.annotation.RabbitListener",
+      "methodParameterTypes": [
+        ".."
+      ],
+      "captureKind": "transaction",
+      "transactionType": "Background",
+      "transactionNameTemplate": "Spring amqp: {{this.class.simpleName}}#{{methodName}}",
+      "traceEntryMessageTemplate": "Spring amqp: {{this.class.name}}.{{methodName}}()",
+      "timerName": "spring amqp"
     }
   ],
   "aspects": [


### PR DESCRIPTION
Hi,

I would like to add `@RabbitListener` annotation support in the spring-plugin.

Here is the documentation related to this spring-amqp feature:
https://docs.spring.io/spring-amqp/reference/html/#async-annotation-driven

Here is the sample spring-rabbitmq project I used to test the spring-plugin configuration I propose to add:
https://github.com/Nowheresly/spring-rabbitmq-glowroot


