### PR TITLE
Allow CASSANDRA_PASSWORD_FILE and CASSANDRA_SYMMETRIC_ENCRYPTION_KEY_…

### DIFF
--- a/central/Dockerfile
+++ b/central/Dockerfile
@@ -15,6 +15,9 @@ EXPOSE 4000 8181
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY glowroot-central.sh /usr/local/bin/
 
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
+             /usr/local/bin/glowroot-central.sh
+
 WORKDIR /usr/share/glowroot-central
 
 USER glowroot:glowroot

--- a/central/README.md
+++ b/central/README.md
@@ -1,0 +1,7 @@
+# How to build the docker image?
+
+Run:
+
+```
+docker build --no-cache -t glowroot/glowroot-central:<version> .
+```

--- a/central/docker-entrypoint.sh
+++ b/central/docker-entrypoint.sh
@@ -1,6 +1,31 @@
 #!/bin/bash
 set -e
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+file_env 'CASSANDRA_PASSWORD'
+file_env 'CASSANDRA_SYMMETRIC_ENCRYPTION_KEY'
+
 if [ "$CASSANDRA_CONTACT_POINTS" ]; then
   sed -i "s/^cassandra.contactPoints=.*$/cassandra.contactPoints=$CASSANDRA_CONTACT_POINTS/" glowroot-central.properties
 fi
@@ -18,6 +43,9 @@ if [ "$CASSANDRA_CONSISTENCY_LEVEL" ]; then
 fi
 if [ "$CASSANDRA_SYMMETRIC_ENCRYPTION_KEY" ]; then
   sed -i "s/^cassandra.symmetricEncryptionKey=.*$/cassandra.symmetricEncryptionKey=$CASSANDRA_SYMMETRIC_ENCRYPTION_KEY/" glowroot-central.properties
+fi
+if [ "$UI_CONTEXT_PATH" ]; then
+  sed -i "s/^ui.contextPath=.*$/ui.contextPath=$UI_CONTEXT_PATH/" glowroot-central.properties
 fi
 
 exec "$@"


### PR DESCRIPTION
…FILE to be used to leverage docker secrets

Adds UI_CONTEXT_PATH to set context path from an env variable.

The goal of this PR is to provide the very same feature we may found in a number of docker images (such as [postgresql](https://github.com/docker-library/postgres/blob/master/11/docker-entrypoint.sh) or [mariadb](https://github.com/docker-library/mariadb/blob/master/10.4/docker-entrypoint.sh) for example) as far as passwords are concerned. 

So, instead of setting `CASSANDRA_PASSWORD` env variable, we may set `CASSANDRA_PASSWORD_FILE` with the path of a file which contains the password to use.

This way, the cassandra password may be provided to the glowroot image through a [docker secret](https://docs.docker.com/engine/swarm/secrets/).

I had to add the `chmod +x` command otherwise the `.sh` files are not executable.