### PR TITLE
Add Jgroups Kubernetes discovery protocol

### DIFF
--- a/central/pom.xml
+++ b/central/pom.xml
@@ -72,7 +72,19 @@
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-core</artifactId>
-      <version>9.4.5.Final</version>
+      <version>9.4.16.Final</version>
+    </dependency>
+    <!-- jgroups-kubernetes specifies that it requires 4.1.x but it works fine with 4.0.x. On the other
+      hand infinispan-core does not work with 4.1.x -->
+    <dependency>
+      <groupId>org.jgroups</groupId>
+      <artifactId>jgroups</artifactId>
+      <version>4.0.21.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jgroups.kubernetes</groupId>
+      <artifactId>jgroups-kubernetes</artifactId>
+      <version>1.0.12.Final</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,12 @@
                 <requireMavenVersion>
                   <version>[3.3.1,)</version>
                 </requireMavenVersion>
-                <requireUpperBoundDeps />
+                <requireUpperBoundDeps>
+                  <excludes>
+                    <!-- Exclude until infinispan-core 10.0 is released -->
+                    <exclude>org.jgroups:jgroups</exclude>
+                  </excludes>
+                </requireUpperBoundDeps>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
We're using this for our own Glowroot cluster and I figured I'd contribute the work in case someone else could make use of it (and also so that we wouldn't have to keep building Central ourselves).

This adds the jgroups-kubernetes discovery protocol such that the Kubernetes cluster API is the authoritative source of jgroups cluster members (ideal when running a Glowroot Central cluster in Kubernetes). 

A Maven Enforcer exclusion has been added for org.jgroups:jgroups as jgroups-kubernetes depends on jgroups 4.1.x however it does work with 4.0.x. This can be removed once infinispan 10.x is released as that version is compatible with jgroups 4.1.x.