### PR TITLE
Format trace duration milliseconds in a more readable way

### DIFF
--- a/ui/app/hbs/trace.hbs
+++ b/ui/app/hbs/trace.hbs
@@ -87,7 +87,7 @@
   <div class="gt-trace-attr-name">Duration:&nbsp;</div>
   <div class="gt-trace-attr-value"><!--
     lack of space here is significant because of gt-pre-wrap (which is mixin to gt-trace-attr-value)
- -->{{nanosToMillis durationNanos}}{{#if active}}..{{^}}{{#if partial}}..{{/if}}{{/if}}&nbsp;milliseconds<!--
+ -->{{nanosToReadable durationNanos}}{{#if active}}..{{^}}{{#if partial}}..{{/if}}{{/if}}<!--
 --></div>
 </div>
 {{#if user}}

--- a/ui/app/hbs/trace.hbs
+++ b/ui/app/hbs/trace.hbs
@@ -85,9 +85,9 @@
 </div>
 <div>
   <div class="gt-trace-attr-name">Duration:&nbsp;</div>
-  <div class="gt-trace-attr-value"><!--
+  <div class="gt-trace-attr-value" title="{{nanosToReadable durationNanos}}"><!--
     lack of space here is significant because of gt-pre-wrap (which is mixin to gt-trace-attr-value)
- -->{{nanosToReadable durationNanos}}{{#if active}}..{{^}}{{#if partial}}..{{/if}}{{/if}}<!--
+ -->{{nanosToMillis durationNanos}}{{#if active}}..{{^}}{{#if partial}}..{{/if}}{{/if}}&nbsp;milliseconds<!--
 --></div>
 </div>
 {{#if user}}
@@ -127,7 +127,7 @@
                 {{name}}
               </div>
             </td>
-            <td>{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
+            <td title="{{nanosToReadable totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
             <td>{{formatInteger count}}</td>
           </tr>
         {{/each}}
@@ -184,7 +184,7 @@
                 </div>
               </div>
             </td>
-            <td>{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
+            <td title="{{nanosToReadable totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
             <td>{{formatInteger count}}</td>
           </tr>
         {{/each}}
@@ -242,7 +242,7 @@
                 {{name}}
               </div>
             </td>
-            <td>{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
+            <td title="{{nanosToReadable totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
             <td>{{formatInteger count}}</td>
           </tr>
         {{/each}}
@@ -298,7 +298,7 @@
                 </div>
               </div>
             </td>
-            <td>{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
+            <td title="{{nanosToReadable totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
             <td>{{formatInteger count}}</td>
           </tr>
         {{/each}}
@@ -356,7 +356,7 @@
                 {{name}}
               </div>
             </td>
-            <td>{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
+            <td title="{{nanosToReadable totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
             <td>{{formatInteger count}}</td>
           </tr>
         {{/each}}

--- a/ui/app/hbs/trace.hbs
+++ b/ui/app/hbs/trace.hbs
@@ -85,7 +85,7 @@
 </div>
 <div>
   <div class="gt-trace-attr-name">Duration:&nbsp;</div>
-  <div class="gt-trace-attr-value" title="{{nanosToReadable durationNanos}}"><!--
+  <div class="gt-trace-attr-value" title="{{formatNanos durationNanos}}"><!--
     lack of space here is significant because of gt-pre-wrap (which is mixin to gt-trace-attr-value)
  -->{{nanosToMillis durationNanos}}{{#if active}}..{{^}}{{#if partial}}..{{/if}}{{/if}}&nbsp;milliseconds<!--
 --></div>
@@ -127,7 +127,7 @@
                 {{name}}
               </div>
             </td>
-            <td title="{{nanosToReadable totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
+            <td title="{{formatNanos totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
             <td>{{formatInteger count}}</td>
           </tr>
         {{/each}}
@@ -184,7 +184,7 @@
                 </div>
               </div>
             </td>
-            <td title="{{nanosToReadable totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
+            <td title="{{formatNanos totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
             <td>{{formatInteger count}}</td>
           </tr>
         {{/each}}
@@ -242,7 +242,7 @@
                 {{name}}
               </div>
             </td>
-            <td title="{{nanosToReadable totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
+            <td title="{{formatNanos totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
             <td>{{formatInteger count}}</td>
           </tr>
         {{/each}}
@@ -298,7 +298,7 @@
                 </div>
               </div>
             </td>
-            <td title="{{nanosToReadable totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
+            <td title="{{formatNanos totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
             <td>{{formatInteger count}}</td>
           </tr>
         {{/each}}
@@ -356,7 +356,7 @@
                 {{name}}
               </div>
             </td>
-            <td title="{{nanosToReadable totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
+            <td title="{{formatNanos totalNanos}}">{{nanosToMillis totalNanos}}{{#if active}}..{{/if}}</td>
             <td>{{formatInteger count}}</td>
           </tr>
         {{/each}}
@@ -372,19 +372,25 @@
   {{#ifNotNA mainThreadStats/totalCpuNanos}}
     <div class="gt-indent2">
       <span>CPU time:</span>
-      {{nanosToMillis mainThreadStats/totalCpuNanos}} milliseconds
+      <span title="{{formatNanos mainThreadStats/totalCpuNanos}}">
+        {{nanosToMillis mainThreadStats/totalCpuNanos}} milliseconds
+      </span>
     </div>
   {{/ifNotNA}}
   {{#ifNotNA mainThreadStats/totalBlockedNanos}}
     <div class="gt-indent2">
       <span>Blocked time:</span>
-      {{nanosToMillis mainThreadStats/totalBlockedNanos}} milliseconds
+      <span title="{{formatNanos mainThreadStats/totalBlockedNanos}}">
+        {{nanosToMillis mainThreadStats/totalBlockedNanos}} milliseconds
+      </span>
     </div>
   {{/ifNotNA}}
   {{#ifNotNA mainThreadStats/totalWaitedNanos}}
     <div class="gt-indent2">
       <span>Waited time:</span>
-      {{nanosToMillis mainThreadStats/totalWaitedNanos}} milliseconds
+      <span title="{{formatNanos mainThreadStats/totalWaitedNanos}}">
+        {{nanosToMillis mainThreadStats/totalWaitedNanos}} milliseconds
+      </span>
     </div>
   {{/ifNotNA}}
   {{#ifNotNA mainThreadStats/totalAllocatedBytes}}
@@ -402,19 +408,25 @@
     {{#ifNotNA auxThreadStats/totalCpuNanos}}
       <div class="gt-indent2">
         <span>CPU time:</span>
-        {{nanosToMillis auxThreadStats/totalCpuNanos}} milliseconds
+        <span title="{{formatNanos auxThreadStats/totalCpuNanos}}">
+          {{nanosToMillis auxThreadStats/totalCpuNanos}} milliseconds
+        </span>
       </div>
     {{/ifNotNA}}
     {{#ifNotNA auxThreadStats/totalBlockedNanos}}
       <div class="gt-indent2">
         <span>Blocked time:</span>
-        {{nanosToMillis auxThreadStats/totalBlockedNanos}} milliseconds
+        <span title="{{formatNanos auxThreadStats/totalBlockedNanos}}">
+          {{nanosToMillis auxThreadStats/totalBlockedNanos}} milliseconds
+        </span>
       </div>
     {{/ifNotNA}}
     {{#ifNotNA auxThreadStats/totalWaitedNanos}}
       <div class="gt-indent2">
         <span>Waited time:</span>
-        {{nanosToMillis auxThreadStats/totalWaitedNanos}} milliseconds
+        <span title="{{formatNanos auxThreadStats/totalWaitedNanos}}">
+          {{nanosToMillis auxThreadStats/totalWaitedNanos}} milliseconds
+        </span>
       </div>
     {{/ifNotNA}}
     {{#ifNotNA auxThreadStats/totalAllocatedBytes}}

--- a/ui/app/scripts/handlebars-rendering.js
+++ b/ui/app/scripts/handlebars-rendering.js
@@ -287,6 +287,10 @@ HandlebarsRendering = (function () {
     return formatMillis(value);
   });
 
+  Handlebars.registerHelper('nanosToReadable', function (value) {
+    return nanosToReadable(value);
+  });
+
   Handlebars.registerHelper('formatInteger', function (value) {
     return value.toLocaleString();
   });
@@ -1634,6 +1638,30 @@ HandlebarsRendering = (function () {
     }
   }
 
+  function nanosToReadable(nanos) {
+    var millis = nanos ? Math.floor(nanos / 1000000) : 0;
+    var hours;
+    var minutes;
+    var seconds;
+    // more than 1 hour
+    if (millis > 3600000) {
+      hours = Math.floor(millis / 3600000);
+      minutes = (millis - hours * 3600000) / 60000;
+      return formatWithExactlyZeroFractionalDigit(hours) + ' '
+          + (hours > 1 ? 'hours' : 'hour') + ' '
+          + formatWithExactlyOneFractionalDigit(minutes) + ' minutes';
+    }
+    // more than 1 minute
+    if (millis > 60000) {
+      minutes = Math.floor(millis / 60000);
+      seconds = (millis - minutes * 60000) / 1000;
+      return formatWithExactlyZeroFractionalDigit(minutes) + ' '
+          + (minutes > 1 ? 'minutes' : 'minute') + ' '
+          + formatWithExactlyOneFractionalDigit(seconds) + ' seconds';
+    }
+    return formatMillis(millis) + ' milliseconds';
+  }
+
   function formatMillis(millis) {
     if (Math.abs(millis) < 0.0000005) {
       // less than 0.5 nanoseconds
@@ -1683,6 +1711,10 @@ HandlebarsRendering = (function () {
 
   function formatWithExactlyOneFractionalDigit(value) {
     return (Math.round(value * 10) / 10).toLocaleString(undefined, {minimumFractionDigits: 1});
+  }
+
+  function formatWithExactlyZeroFractionalDigit(value) {
+    return Math.round(value).toLocaleString(undefined);
   }
 
   function registerShowMoreHandler(breakdown) {

--- a/ui/app/scripts/handlebars-rendering.js
+++ b/ui/app/scripts/handlebars-rendering.js
@@ -287,8 +287,8 @@ HandlebarsRendering = (function () {
     return formatMillis(value);
   });
 
-  Handlebars.registerHelper('nanosToReadable', function (value) {
-    return nanosToReadable(value);
+  Handlebars.registerHelper('formatNanos', function (value) {
+    return formatNanos(value);
   });
 
   Handlebars.registerHelper('formatInteger', function (value) {
@@ -1638,7 +1638,7 @@ HandlebarsRendering = (function () {
     }
   }
 
-  function nanosToReadable(nanos) {
+  function formatNanos(nanos) {
     var millis = nanos ? Math.floor(nanos / 1000000) : 0;
     var hours;
     var minutes;


### PR DESCRIPTION
3690,123.4 milliseconds -> 1 hour 1.5 minutes
122,123.7 milliseconds -> 2 minutes 2.1 seconds
34,000.8 milliseconds -> 34,000.8 milliseconds