### PR TITLE
Buggy implementation of file object can lead to nullpointerexception

### DIFF
--- a/agent/plugins/servlet-plugin/src/main/java/org/glowroot/agent/plugin/servlet/HttpSessions.java
+++ b/agent/plugins/servlet-plugin/src/main/java/org/glowroot/agent/plugin/servlet/HttpSessions.java
@@ -98,7 +98,13 @@ public class HttpSessions {
                 // request for the same session just removed the attribute
                 continue;
             }
-            captureMap.put(attributeName, Strings.nullToEmpty(value.toString()));
+	    // Buggy implementation of file object can lead to nullpointerexception
+            try {
+            	captureMap.put(attributeName, Strings.nullToEmpty(value.toString()));
+            }
+            catch (NullPointerException npe) {
+            	continue;
+            }
         }
     }
 


### PR DESCRIPTION
2020-02-04 09:49:20,228 ERROR [io.undertow.request] (undertow task-4) UT005023: Exception handling request to ...: java.lang.NullPointerException
	at org.apache.commons.fileupload.disk.DiskFileItem.getSize(DiskFileItem.java:288)
	at org.apache.commons.fileupload.disk.DiskFileItem.toString(DiskFileItem.java:620)
	at java.lang.String.valueOf(String.java:2994) [rt.jar:1.8.0_222]
	at java.lang.StringBuilder.append(StringBuilder.java:131) [rt.jar:1.8.0_222]
	at java.util.AbstractCollection.toString(AbstractCollection.java:462) [rt.jar:1.8.0_222]
	at org.glowroot.agent.plugin.servlet.HttpSessions.captureAllSessionAttributes(HttpSessions.java:98) [glowroot.jar:0.10.11]