### PR TITLE
Fix tombstone_warn_threshold cassandra warning

### DIFF
--- a/central/src/main/java/org/glowroot/central/repo/AgentConfigDao.java
+++ b/central/src/main/java/org/glowroot/central/repo/AgentConfigDao.java
@@ -102,7 +102,7 @@ public class AgentConfigDao {
             // agent will not consider collectInit() to be successful until it receives updated
             // agent config
             boundStatement.setBool(i++, false);
-            boundStatement.setToNull(i++);
+            boundStatement.unset(i++);
             session.write(boundStatement);
             agentConfigCache.invalidate(agentId);
         }
@@ -129,7 +129,7 @@ public class AgentConfigDao {
                         .build()
                         .toByteArray()));
                 boundStatement.setBool(i++, false);
-                boundStatement.setToNull(i++);
+                boundStatement.unset(i++);
                 session.write(boundStatement);
                 agentConfigCache.invalidate(loopAgentRollupId);
             }

--- a/central/src/main/java/org/glowroot/central/repo/AggregateDaoImpl.java
+++ b/central/src/main/java/org/glowroot/central/repo/AggregateDaoImpl.java
@@ -1313,11 +1313,11 @@ public class AggregateDaoImpl implements AggregateDao {
         boundStatement.setDouble(i++, mainThreadStats.getTotalWaitedNanos());
         boundStatement.setDouble(i++, mainThreadStats.getTotalAllocatedBytes());
         if (auxThreadRootTimer.getCount() == 0) {
-            boundStatement.setToNull(i++);
-            boundStatement.setToNull(i++);
-            boundStatement.setToNull(i++);
-            boundStatement.setToNull(i++);
-            boundStatement.setToNull(i++);
+            boundStatement.unset(i++);
+            boundStatement.unset(i++);
+            boundStatement.unset(i++);
+            boundStatement.unset(i++);
+            boundStatement.unset(i++);
         } else {
             // writing as delimited singleton list for backwards compatibility with data written
             // prior to 0.12.0
@@ -1329,7 +1329,7 @@ public class AggregateDaoImpl implements AggregateDao {
             boundStatement.setDouble(i++, auxThreadStats.getTotalAllocatedBytes());
         }
         if (asyncTimers.isEmpty()) {
-            boundStatement.setToNull(i++);
+            boundStatement.unset(i++);
         } else {
             boundStatement.setBytes(i++,
                     Messages.toByteBuffer(MutableAggregate.toProto(asyncTimers)));
@@ -1449,7 +1449,7 @@ public class AggregateDaoImpl implements AggregateDao {
         boundStatement.setTimestamp(i++, new Date(query.to()));
         boundStatement.setLong(i++, transactionCount);
         if (hasMissingErrorCount) {
-            boundStatement.setToNull(i++);
+            boundStatement.unset(i++);
         } else {
             boundStatement.setLong(i++, errorCount);
         }
@@ -1851,7 +1851,7 @@ public class AggregateDaoImpl implements AggregateDao {
             if (query.hasTotalRows()) {
                 boundStatement.setLong(i++, query.getTotalRows().getValue());
             } else {
-                boundStatement.setToNull(i++);
+                boundStatement.unset(i++);
             }
             boundStatement.setInt(i++, adjustedTTL.queryTTL());
             futures.add(session.writeAsync(boundStatement));
@@ -1887,7 +1887,7 @@ public class AggregateDaoImpl implements AggregateDao {
             if (query.hasTotalRows()) {
                 boundStatement.setLong(i++, query.getTotalRows());
             } else {
-                boundStatement.setToNull(i++);
+                boundStatement.unset(i++);
             }
             boundStatement.setInt(i++, adjustedTTL.queryTTL());
             futures.add(session.writeAsync(boundStatement));
@@ -2122,15 +2122,15 @@ public class AggregateDaoImpl implements AggregateDao {
                 boundStatement.setDouble(i++, auxThreadStats.getTotalAllocatedBytes());
             }
         } else {
-            boundStatement.setToNull(i++);
-            boundStatement.setToNull(i++);
-            boundStatement.setToNull(i++);
-            boundStatement.setToNull(i++);
-            boundStatement.setToNull(i++);
+            boundStatement.unset(i++);
+            boundStatement.unset(i++);
+            boundStatement.unset(i++);
+            boundStatement.unset(i++);
+            boundStatement.unset(i++);
         }
         List<Aggregate.Timer> asyncTimers = aggregate.getAsyncTimerList();
         if (asyncTimers.isEmpty()) {
-            boundStatement.setToNull(i++);
+            boundStatement.unset(i++);
         } else {
             boundStatement.setBytes(i++, Messages.toByteBuffer(asyncTimers));
         }

--- a/central/src/main/java/org/glowroot/central/repo/SyntheticResultDaoImpl.java
+++ b/central/src/main/java/org/glowroot/central/repo/SyntheticResultDaoImpl.java
@@ -168,7 +168,7 @@ public class SyntheticResultDaoImpl implements SyntheticResultDao {
         boundStatement.setDouble(i++, durationNanos);
         boundStatement.setLong(i++, 1);
         if (errorMessage == null) {
-            boundStatement.setToNull(i++);
+            boundStatement.unset(i++);
         } else {
             Stored.ErrorInterval errorInterval = Stored.ErrorInterval.newBuilder()
                     .setFrom(captureTime)
@@ -372,7 +372,7 @@ public class SyntheticResultDaoImpl implements SyntheticResultDao {
         boundStatement.setLong(i++, executionCount);
         List<ErrorInterval> mergedErrorIntervals = errorIntervalCollector.getMergedErrorIntervals();
         if (mergedErrorIntervals.isEmpty()) {
-            boundStatement.setToNull(i++);
+            boundStatement.unset(i++);
         } else {
             boundStatement.setBytes(i++, Messages.toByteBuffer(toProto(mergedErrorIntervals)));
         }

--- a/central/src/main/java/org/glowroot/central/repo/TraceDaoImpl.java
+++ b/central/src/main/java/org/glowroot/central/repo/TraceDaoImpl.java
@@ -768,7 +768,7 @@ public class TraceDaoImpl implements TraceDao {
             boundStatement.setLong(i++, entry.getDurationNanos());
             boundStatement.setBool(i++, entry.getActive());
             if (entry.hasQueryEntryMessage()) {
-                boundStatement.setToNull(i++);
+                boundStatement.unset(i++);
                 boundStatement.setInt(i++, entry.getQueryEntryMessage().getSharedQueryTextIndex());
                 boundStatement.setString(i++,
                         Strings.emptyToNull(entry.getQueryEntryMessage().getPrefix()));
@@ -777,26 +777,26 @@ public class TraceDaoImpl implements TraceDao {
             } else {
                 // message is empty for trace entries added using addErrorEntry()
                 boundStatement.setString(i++, Strings.emptyToNull(entry.getMessage()));
-                boundStatement.setToNull(i++);
-                boundStatement.setToNull(i++);
-                boundStatement.setToNull(i++);
+                boundStatement.unset(i++);
+                boundStatement.unset(i++);
+                boundStatement.unset(i++);
             }
             List<Trace.DetailEntry> detailEntries = entry.getDetailEntryList();
             if (detailEntries.isEmpty()) {
-                boundStatement.setToNull(i++);
+                boundStatement.unset(i++);
             } else {
                 boundStatement.setBytes(i++, Messages.toByteBuffer(detailEntries));
             }
             List<StackTraceElement> location = entry.getLocationStackTraceElementList();
             if (location.isEmpty()) {
-                boundStatement.setToNull(i++);
+                boundStatement.unset(i++);
             } else {
                 boundStatement.setBytes(i++, Messages.toByteBuffer(location));
             }
             if (entry.hasError()) {
                 boundStatement.setBytes(i++, ByteBuffer.wrap(entry.getError().toByteArray()));
             } else {
-                boundStatement.setToNull(i++);
+                boundStatement.unset(i++);
             }
             boundStatement.setInt(i++, adjustedTTL);
             futures.add(session.writeAsync(boundStatement));
@@ -835,8 +835,8 @@ public class TraceDaoImpl implements TraceDao {
                 boundStatement.setString(i++, sharedQueryText.getFullTextSha1());
             } else {
                 boundStatement.setString(i++, fullText);
-                boundStatement.setToNull(i++);
-                boundStatement.setToNull(i++);
+                boundStatement.unset(i++);
+                boundStatement.unset(i++);
             }
             boundStatement.setInt(i++, adjustedTTL);
             futures.add(session.writeAsync(boundStatement));
@@ -1312,7 +1312,7 @@ public class TraceDaoImpl implements TraceDao {
         if (partial) {
             if (cassandra2x) {
                 // don't set real_capture_time, so this still looks like data prior to 0.13.1
-                boundStatement.setToNull(i++);
+                boundStatement.unset(i++);
             } else {
                 boundStatement.setTimestamp(i++, new Date(header.getCaptureTime()));
             }
@@ -1323,7 +1323,7 @@ public class TraceDaoImpl implements TraceDao {
         boundStatement.setString(i++, Strings.emptyToNull(header.getUser()));
         List<Trace.Attribute> attributes = header.getAttributeList();
         if (attributes.isEmpty()) {
-            boundStatement.setToNull(i++);
+            boundStatement.unset(i++);
         } else {
             boundStatement.setBytes(i++, Messages.toByteBuffer(attributes));
         }
@@ -1338,7 +1338,7 @@ public class TraceDaoImpl implements TraceDao {
         if (partial) {
             if (cassandra2x) {
                 // don't set real_capture_time, so this still looks like data prior to 0.13.1
-                boundStatement.setToNull(i++);
+                boundStatement.unset(i++);
             } else {
                 boundStatement.setTimestamp(i++, new Date(header.getCaptureTime()));
             }
@@ -1363,7 +1363,7 @@ public class TraceDaoImpl implements TraceDao {
         boundStatement.setString(i++, Strings.emptyToNull(header.getUser()));
         List<Trace.Attribute> attributes = header.getAttributeList();
         if (attributes.isEmpty()) {
-            boundStatement.setToNull(i++);
+            boundStatement.unset(i++);
         } else {
             boundStatement.setBytes(i++, Messages.toByteBuffer(attributes));
         }


### PR DESCRIPTION
Fix for #603 . According to [https://docs.datastax.com/en/developer/java-driver/4.1/manual/core/statements/prepared/#unset-values](https://docs.datastax.com/en/developer/java-driver/4.1/manual/core/statements/prepared/#unset-values) this should fix unnecessary tombstone creation. The only downside would be that unset is not supported by Cassandra [2.1](https://github.com/glowroot/glowroot/wiki/Central-Collector-Installation#requirements)