### PR TITLE
Improve operability when operating with third-party agents

### DIFF
--- a/agent/core/src/main/java/org/glowroot/agent/weaving/WeavingClassFileTransformer.java
+++ b/agent/core/src/main/java/org/glowroot/agent/weaving/WeavingClassFileTransformer.java
@@ -122,6 +122,10 @@ public class WeavingClassFileTransformer implements ClassFileTransformer {
             // don't weave glowroot core classes, including shaded classes like h2 jdbc driver
             return true;
         }
+        if (isThirdPartyAgentClass(className)) {
+            // special case to avoid weaving errors with third-party agents
+            return true;
+        }
         if (className.startsWith("sun/reflect/Generated")) {
             // optimization, no need to try to weave the many classes generated for reflection:
             // sun/reflect/GeneratedSerializationConstructorAccessor..
@@ -163,5 +167,9 @@ public class WeavingClassFileTransformer implements ClassFileTransformer {
 
     private static boolean isInBootstrapClassLoader() {
         return WeavingClassFileTransformer.class.getClassLoader() == null;
+    }
+
+    private static boolean isThirdPartyAgentClass(String className) {
+        return className.startsWith("com/contrastsecurity/");
     }
 }


### PR DESCRIPTION
Heya @trask 

This PR fixes compatibility with the Contrast agent and adds enough genericness to expand this to other agents.  This sort of blacklist prevents both `ClassCircularityError` and `AbstractMethodError` from occurring during the bootstrap of either agent.