### PR TITLE
Add password support for ldap settings in admin-default.json

### DIFF
--- a/central/docker-entrypoint.sh
+++ b/central/docker-entrypoint.sh
@@ -53,6 +53,9 @@ fi
 if [ "$CASSANDRA_CONFIGURATION_FILE" ]; then
   sed -i "s/^cassandra.configurationFile=.*$/cassandra.configurationFile=$CASSANDRA_CONFIGURATION_FILE/" glowroot-central.properties
 fi
+if [ "$HELM_MODE" ]; then
+  sed -i "s/^helmMode=.*$/helmMode=$HELM_MODE/" glowroot-central.properties
+fi
 if [ "$UI_CONTEXT_PATH" ]; then
   # not using "/" as sed delimiter since it is a common character used in context path
   sed -i "s|^ui.contextPath=.*$|ui.contextPath=$UI_CONTEXT_PATH|" glowroot-central.properties

--- a/central/src/main/conf/glowroot-central.properties
+++ b/central/src/main/conf/glowroot-central.properties
@@ -31,6 +31,13 @@ cassandra.configurationFile=
 # default is 4h. For CosmosDB Cassandra API, set this value to 0.
 cassandra.gcGraceSeconds=
 
+# default is false. 
+# set this to true to run glowroot in helm mode
+# helm mode will cause the admin-default.json to be your source of truth
+# on restart, glowroot will override your configuration with the admin-default.json
+# the helm chart will generate an admin-default.json out of its values
+helmMode=
+
 # default is grpc.bindAddress=0.0.0.0
 grpc.bindAddress=
 

--- a/central/src/main/java/org/glowroot/central/repo/CentralRepoModule.java
+++ b/central/src/main/java/org/glowroot/central/repo/CentralRepoModule.java
@@ -73,8 +73,6 @@ public class CentralRepoModule {
             int targetMaxActiveAgentsInPast7Days, int targetMaxCentralUiUsers, Clock clock)
             throws Exception {
 
-        boolean populateFromAdminDefault = session.getTable("central_config") == null;
-
         CentralConfigDao centralConfigDao = new CentralConfigDao(session, clusterManager);
         agentDisplayDao = new AgentDisplayDao(session, clusterManager, asyncExecutor,
                 targetMaxActiveAgentsInPast7Days);
@@ -96,19 +94,18 @@ public class CentralRepoModule {
         traceAttributeNameDao = new TraceAttributeNameDao(session, configRepository, clusterManager,
                 targetMaxCentralUiUsers);
 
-        if (populateFromAdminDefault) {
-            File adminDefaultFile = new File(confDir, "admin-default.json");
-            if (adminDefaultFile.exists()) {
-                try {
-                    populateFromAdminDefault(adminDefaultFile, configRepository);
-                } catch (Exception e) {
-                    // drop the table so that after fixing admin-default.json re-import will occur
-                    session.updateSchemaWithRetry("drop table central_config");
-                    throw e;
-                }
-            }
-        }
+        File adminDefaultFile = new File(confDir, "admin-default.json");
 
+        if (adminDefaultFile.exists()) {
+            try {
+                populateFromAdminDefault(adminDefaultFile, configRepository);
+            } catch (Exception e) {
+                // drop the table so that after fixing admin-default.json re-import will occur
+                session.updateSchemaWithRetry("drop table central_config");
+                throw e;
+            }
+        }         
+        
         Set<String> agentRollupIdsWithV09Data;
         long v09LastCaptureTime;
         long v09FqtLastExpirationTime;

--- a/central/src/main/java/org/glowroot/central/repo/CentralRepoModule.java
+++ b/central/src/main/java/org/glowroot/central/repo/CentralRepoModule.java
@@ -69,10 +69,10 @@ public class CentralRepoModule {
     private final V09AgentRollupDao v09AgentRollupDao;
 
     public CentralRepoModule(ClusterManager clusterManager, Session session, File confDir,
-            String cassandraSymmetricEncryptionKey, int cassandraGcGraceSeconds, Boolean helmMode, ExecutorService asyncExecutor,
+            String cassandraSymmetricEncryptionKey, int cassandraGcGraceSeconds, boolean helmMode, ExecutorService asyncExecutor,
             int targetMaxActiveAgentsInPast7Days, int targetMaxCentralUiUsers, Clock clock)
             throws Exception {
-        
+
         boolean populateFromAdminDefault = session.getTable("central_config") == null;
 
         CentralConfigDao centralConfigDao = new CentralConfigDao(session, clusterManager);
@@ -107,9 +107,9 @@ public class CentralRepoModule {
                     session.updateSchemaWithRetry("drop table central_config");
                     throw e;
                 }
-            }         
+            }
         }
-        
+
         Set<String> agentRollupIdsWithV09Data;
         long v09LastCaptureTime;
         long v09FqtLastExpirationTime;

--- a/common2/src/main/java/org/glowroot/common2/config/LdapConfig.java
+++ b/common2/src/main/java/org/glowroot/common2/config/LdapConfig.java
@@ -52,6 +52,12 @@ public abstract class LdapConfig {
 
     @Value.Default
     @JsonInclude(Include.NON_EMPTY)
+    public String password() {
+        return "";
+    }
+    
+    @Value.Default
+    @JsonInclude(Include.NON_EMPTY)
     public String encryptedPassword() {
         return "";
     }

--- a/common2/src/main/java/org/glowroot/common2/repo/AllAdminConfigUtil.java
+++ b/common2/src/main/java/org/glowroot/common2/repo/AllAdminConfigUtil.java
@@ -57,8 +57,8 @@ public class AllAdminConfigUtil {
         if (objectNode == null) {
             return;
         }
-        // FIXME remove()??
-        JsonNode passwordNode = objectNode.get("password");
+
+        JsonNode passwordNode = objectNode.remove("password");
         if (passwordNode == null) {
             JsonNode encryptedPasswordNode = objectNode.get("encryptedPassword");
             if (encryptedPasswordNode == null) {


### PR DESCRIPTION
This PR also introduces the ability to upgrade the database with the admin-default.json

Once a admin-default.json is present it will override the settings. This is needed in order to support an upgradeable helm chart.

However i know that this might not be the optimal solution. I also thought about using the admin-default.json  as it is now and support an admin.json file in the root directory which will support the upgrade/override feature described above.

This PR referes to Issue: #729 