### PR TITLE
read agent.id from env if not set in properties

### DIFF
--- a/agent/core/src/main/java/org/glowroot/agent/central/CentralCollector.java
+++ b/agent/core/src/main/java/org/glowroot/agent/central/CentralCollector.java
@@ -112,6 +112,10 @@ public class CentralCollector implements Collector {
             ConfigService configService) throws Exception {
 
         String agentId = properties.get("glowroot.agent.id");
+        // allow glowroot to read agentId from ENV
+        if(agentId==null) {
+            agentId = System.getenv("GLOWROOT_AGENT_ID");
+        }
         if (agentId == null) {
             agentId = escapeHostname(InetAddress.getLocalHost().getHostName());
         } else if (agentId.endsWith("::")) {


### PR DESCRIPTION
This allows glowroot to read its agent Id from the environment if it is not set in the properties file.  This allows glowroot to be used in a containerized environment, by setting `GLOWROOT_AGENT_ID'  to something like `prod.cluster.com::`.  In this case, glowroot would append the hostName to the prod.cluster.com making the data more usable in the collector.

