### PR TITLE
Upd assertj 3.21.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,8 +225,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <!-- assertj 2.0.0+ requires Java 7+ -->
-        <version>1.7.1</version>
+        <version>3.21.0</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>


### PR DESCRIPTION
Hi @trask, this is a very simple PR to upgrade assertj.
You could find here informations abbout assertj releases:
https://assertj.github.io/doc/#assertj-core-java-versions

Since we are now using java8, it is safe to switch to the latest version of assertj.