### PR TITLE
Upd logback + slf4j upgrade

### DIFF
--- a/agent/plugins/logger-plugin/pom.xml
+++ b/agent/plugins/logger-plugin/pom.xml
@@ -18,8 +18,8 @@
 
   <properties>
     <!-- instrumented libraries -->
-    <logback.version>1.2.3</logback.version>
-    <slf4j.version>1.7.30</slf4j.version>
+    <logback.version>1.2.6</logback.version>
+    <slf4j.version>1.7.32</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <!-- need to update instrumentation for 2.12.1+ !! -->
     <log4j2x.version>2.12.0</log4j2x.version>

--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,8 @@
     <protoc.version>3.18.1</protoc.version>
     <!-- need to stick to netty version that is used by grpc version above -->
     <netty.version>4.1.52.Final</netty.version>
-    <logback.version>1.2.3</logback.version>
-    <slf4j.version>1.7.30</slf4j.version>
+    <logback.version>1.2.6</logback.version>
+    <slf4j.version>1.7.32</slf4j.version>
     <immutables.version>2.8.8</immutables.version>
     <checker.version>3.18.1</checker.version>
     <jmh.version>1.23</jmh.version>


### PR DESCRIPTION
These 2 libs seem safe to be upgraded to the latest stable version.

https://github.com/qos-ch/slf4j/compare/v_1.7.30...v_1.7.32

https://github.com/qos-ch/logback/compare/v_1.2.3...v_1.2.6