### PR TITLE
Fix `Copied!` tooltip

### DIFF
--- a/ui/app/scripts/clipboard.js
+++ b/ui/app/scripts/clipboard.js
@@ -44,9 +44,12 @@ window.gtClipboard = function (clipboardSelector, clipboardContainer, textFn) {
     $clipboardIcon.tooltip(tooltipOptions);
 
     clipboard.on('success', function () {
-      $clipboardIcon.attr('title', 'Copied!')
+      $clipboardIcon.attr('data-original-title', 'Copied!')
           .tooltip('show');
-      $clipboardIcon.attr('title', 'Copy to clipboard');
+      setTimeout(function () {
+          $clipboardIcon.tooltip('hide');
+          $clipboardIcon.attr('data-original-title', 'Copy to clipboard');
+        }, 1000);
     });
 
     $clipboardIcon.data('gtClipboard', true);


### PR DESCRIPTION
Hi @trask ,

This solves a bug related to `Copy to clipboard` button. The tooltip text wasn't changing to `Copied!` after clicking on it

![image](https://user-images.githubusercontent.com/6136404/143491744-51de86ed-9b1b-4aad-b075-91c8c24c504f.png)
