### PR TITLE
Fix inaccurate free space checking

### DIFF
--- a/agent/core/src/main/java/org/glowroot/agent/init/FileSystem.java
+++ b/agent/core/src/main/java/org/glowroot/agent/init/FileSystem.java
@@ -32,12 +32,12 @@ class FileSystem implements FileSystemMXBean {
 
     @Override
     public long getFreeSpace() {
-        return file.getFreeSpace();
+        return file.getUsableSpace();
     }
 
     @Override
     public double getPercentFull() {
         long totalSpace = file.getTotalSpace();
-        return 100 * ((totalSpace - file.getFreeSpace()) / (double) totalSpace);
+        return 100 * ((totalSpace - file.getUsableSpace()) / (double) totalSpace);
     }
 }

--- a/agent/core/src/main/java/org/glowroot/agent/live/LiveJvmServiceImpl.java
+++ b/agent/core/src/main/java/org/glowroot/agent/live/LiveJvmServiceImpl.java
@@ -134,7 +134,7 @@ public class LiveJvmServiceImpl implements LiveJvmService {
         if (!dir.exists() || !dir.isDirectory()) {
             throw new DirectoryDoesNotExistException();
         }
-        return dir.getFreeSpace();
+        return dir.getUsableSpace();
     }
 
     @Override


### PR DESCRIPTION
[https://docs.oracle.com/javase/8/docs/api/java/io/File.html#getUsableSpace--](https://docs.oracle.com/javase/8/docs/api/java/io/File.html#getUsableSpace--)
> Returns the number of bytes available to this virtual machine on the partition named by this abstract pathname. When possible, this method checks for write permissions and other operating system restrictions and will therefore usually provide a more accurate estimate of how much new data can actually be written than getFreeSpace().