### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -718,6 +718,7 @@
                 <!-- needed to suppress "bootstrap class path not set in conjunction with -source 1.6" -->
                 <arg>-Xlint:-options</arg>
               </compilerArgs>
+          	<fork>true</fork>
             </configuration>
             <dependencies>
               <dependency>
@@ -876,6 +877,7 @@
                 <arg>-Astubs=${checker.stubs.dir}</arg>
                 <arg>-AskipDefs=^org\.glowroot\.agent\.embedded\.repo\.proto\.|^org\.glowroot\.agent\.it\.harness\.grpc\.|^org\.glowroot\.central\.repo\.proto\.</arg>
               </compilerArgs>
+          	<fork>true</fork>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION

Maven allows you to run the compiler as a separate process by setting `<fork>true</fork>`. This feature can lead to much less garbage collection and make Maven build faster. This project has more than 1000 source files. We can consider enabling this feature.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
