### PR TITLE
Fix Docker image unable to find group glowroot

### DIFF
--- a/central/Dockerfile
+++ b/central/Dockerfile
@@ -18,7 +18,7 @@ EXPOSE 4000 8181
 
 WORKDIR /usr/share/glowroot-central
 
-USER glowroot:glowroot
+USER glowroot:root
 
 ENV GLOWROOT_OPTS -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
 


### PR DESCRIPTION
Hi @trask 
it seems there was a small issue in PR #774 . The group glowroot does not exist anymore, thus the user can't be `glowroot:.glowroot` anymore.
This PR fixes this issue.

Example:
`docker run --rm -it glowroot/glowroot-central:0.14.beta3 bash`

crash with error:
`docker: Error response from daemon: unable to find group glowroot: no matching entries in group file.`

Sorry for not spotting this previously...