### PR TITLE
Optimize docker image size

### DIFF
--- a/central/Dockerfile
+++ b/central/Dockerfile
@@ -18,7 +18,7 @@ EXPOSE 4000 8181
 
 WORKDIR /usr/share/glowroot-central
 
-USER glowroot:glowroot
+USER glowroot:root
 
 ENV GLOWROOT_OPTS -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
 

--- a/central/Dockerfile
+++ b/central/Dockerfile
@@ -1,15 +1,19 @@
-FROM openjdk:8
+FROM openjdk:8 as builder
 
 COPY target/glowroot-central-*.zip /tmp/glowroot-central.zip
+RUN useradd --no-log-init -r -g root glowroot
+RUN unzip -d /tmp /tmp/glowroot-central.zip \
+    && chown -R glowroot:root /tmp/glowroot-central \
+    && chmod -R g+rw /tmp/glowroot-central
+
+FROM openjdk:8
+
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY glowroot-central.sh /usr/local/bin/
 
-RUN unzip -d /usr/share /tmp/glowroot-central.zip \
-    && rm /tmp/glowroot-central.zip \
-    && useradd --no-log-init -r -g root glowroot \
-    && chown -R glowroot:root /usr/share/glowroot-central \
-    && chmod -R g+rw /usr/share/glowroot-central \
-    && chmod a+x /usr/local/bin/docker-entrypoint.sh \
+RUN useradd --no-log-init -r -g root glowroot
+COPY --from=builder --chown=glowroot:root /tmp/glowroot-central /usr/share/glowroot-central
+RUN chmod a+x /usr/local/bin/docker-entrypoint.sh \
     && chmod a+x /usr/local/bin/glowroot-central.sh \
     && sed -i 's/^cassandra.contactPoints=$/cassandra.contactPoints=cassandra/' /usr/share/glowroot-central/glowroot-central.properties \
     && echo '\ncassandra.symmetricEncryptionKey=' >> /usr/share/glowroot-central/glowroot-central.properties


### PR DESCRIPTION
While doing PR #907 , I realized that a small optimization could be done to the dockerfile so that the size of the image could be reduced.

By running the following command:
`docker history glowroot/glowroot-central:0.14.0-beta.2`
we can see the following output:
```
IMAGE          CREATED        CREATED BY                                      SIZE      COMMENT
e8d2b2bfd824   4 months ago   CMD ["glowroot-central.sh"]                     0B        buildkit.dockerfile.v0
<missing>      4 months ago   ENTRYPOINT ["docker-entrypoint.sh"]             0B        buildkit.dockerfile.v0
<missing>      4 months ago   ENV GLOWROOT_OPTS=-XX:+UnlockExperimentalVMO…   0B        buildkit.dockerfile.v0
<missing>      4 months ago   USER glowroot:glowroot                          0B        buildkit.dockerfile.v0
<missing>      4 months ago   WORKDIR /usr/share/glowroot-central             0B        buildkit.dockerfile.v0
<missing>      4 months ago   EXPOSE map[4000/tcp:{} 8181/tcp:{}]             0B        buildkit.dockerfile.v0
<missing>      4 months ago   RUN /bin/sh -c unzip -d /usr/share /tmp/glow…   50.8MB    buildkit.dockerfile.v0
<missing>      4 months ago   COPY glowroot-central.sh /usr/local/bin/ # b…   90B       buildkit.dockerfile.v0
<missing>      4 months ago   COPY docker-entrypoint.sh /usr/local/bin/ # …   2.12kB    buildkit.dockerfile.v0
<missing>      4 months ago   COPY target/glowroot-central-*.zip /tmp/glow…   46.5MB    buildkit.dockerfile.v0
<missing>      6 months ago   /bin/sh -c set -eux;   arch="$(dpkg --print-…   209MB     
<missing>      6 months ago   /bin/sh -c #(nop)  ENV JAVA_VERSION=8u302       0B        
<missing>      6 months ago   /bin/sh -c #(nop)  ENV LANG=C.UTF-8             0B        
<missing>      6 months ago   /bin/sh -c #(nop)  ENV PATH=/usr/local/openj…   0B        
<missing>      6 months ago   /bin/sh -c { echo '#/bin/sh'; echo 'echo "$J…   27B       
<missing>      6 months ago   /bin/sh -c #(nop)  ENV JAVA_HOME=/usr/local/…   0B        
<missing>      6 months ago   /bin/sh -c set -eux;  apt-get update;  apt-g…   11.3MB    
<missing>      6 months ago   /bin/sh -c apt-get update && apt-get install…   152MB     
<missing>      6 months ago   /bin/sh -c set -ex;  if ! command -v gpg > /…   18.9MB    
<missing>      6 months ago   /bin/sh -c set -eux;  apt-get update;  apt-g…   10.7MB    
<missing>      6 months ago   /bin/sh -c #(nop)  CMD ["bash"]                 0B        
<missing>      6 months ago   /bin/sh -c #(nop) ADD file:1fedf68870782f1b4…   124MB     
```

We can see that adding the zip file and then unzipping it later produce 2 layers of size 46.5MB and 50.8MB.

The idea behind the PR is to use [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/). The zpi file is added, unzipped and chmoded in the build layer so we can copy a ready to use folder of glowroot-central to the target image.

This way, we can see that the layer of 46.5MB is no more included in the final image.
```
docker history glowroot/glowroot-central:0.14.beta3            
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
128518901552   19 minutes ago   CMD ["glowroot-central.sh"]                     0B        buildkit.dockerfile.v0
<missing>      19 minutes ago   ENTRYPOINT ["docker-entrypoint.sh"]             0B        buildkit.dockerfile.v0
<missing>      19 minutes ago   ENV GLOWROOT_OPTS=-XX:+UnlockExperimentalVMO…   0B        buildkit.dockerfile.v0
<missing>      19 minutes ago   USER glowroot:root                              0B        buildkit.dockerfile.v0
<missing>      19 minutes ago   WORKDIR /usr/share/glowroot-central             0B        buildkit.dockerfile.v0
<missing>      19 minutes ago   EXPOSE map[4000/tcp:{} 8181/tcp:{}]             0B        buildkit.dockerfile.v0
<missing>      19 minutes ago   RUN /bin/sh -c useradd -u 1500 --no-log-init…   8.65kB    buildkit.dockerfile.v0
<missing>      19 minutes ago   COPY /tmp/glowroot-central /usr/share/glowro…   50.8MB    buildkit.dockerfile.v0
<missing>      27 minutes ago   COPY glowroot-central.sh /usr/local/bin/ # b…   90B       buildkit.dockerfile.v0
<missing>      27 minutes ago   COPY docker-entrypoint.sh /usr/local/bin/ # …   2.12kB    buildkit.dockerfile.v0
<missing>      2 days ago       /bin/sh -c set -eux;   arch="$(dpkg --print-…   209MB     
<missing>      2 days ago       /bin/sh -c #(nop)  ENV JAVA_VERSION=8u322       0B        
<missing>      2 days ago       /bin/sh -c #(nop)  ENV LANG=C.UTF-8             0B        
<missing>      2 days ago       /bin/sh -c #(nop)  ENV PATH=/usr/local/openj…   0B        
<missing>      2 days ago       /bin/sh -c { echo '#/bin/sh'; echo 'echo "$J…   27B       
<missing>      2 days ago       /bin/sh -c #(nop)  ENV JAVA_HOME=/usr/local/…   0B        
<missing>      2 days ago       /bin/sh -c set -eux;  apt-get update;  apt-g…   11.3MB    
<missing>      3 days ago       /bin/sh -c apt-get update && apt-get install…   152MB     
<missing>      3 days ago       /bin/sh -c set -ex;  if ! command -v gpg > /…   18.9MB    
<missing>      3 days ago       /bin/sh -c set -eux;  apt-get update;  apt-g…   10.7MB    
<missing>      4 days ago       /bin/sh -c #(nop)  CMD ["bash"]                 0B        
<missing>      4 days ago       /bin/sh -c #(nop) ADD file:19873be7a1c793d8e…   124MB     

```