### PR TITLE
grant g+w to /usr/share/glowroot-central before sed invocation

### DIFF
--- a/central/Dockerfile
+++ b/central/Dockerfile
@@ -13,14 +13,13 @@ COPY glowroot-central.sh /usr/local/bin/
 
 RUN useradd --no-log-init -r -g root glowroot
 COPY --from=builder --chown=glowroot:root /tmp/glowroot-central /usr/share/glowroot-central
+WORKDIR /usr/share/glowroot-central
 RUN chmod a+x /usr/local/bin/docker-entrypoint.sh \
     && chmod a+x /usr/local/bin/glowroot-central.sh \
     && sed -i 's/^cassandra.contactPoints=$/cassandra.contactPoints=cassandra/' /usr/share/glowroot-central/glowroot-central.properties \
     && echo '\ncassandra.symmetricEncryptionKey=' >> /usr/share/glowroot-central/glowroot-central.properties
 
 EXPOSE 4000 8181
-
-WORKDIR /usr/share/glowroot-central
 
 USER glowroot:root
 

--- a/central/Dockerfile
+++ b/central/Dockerfile
@@ -17,6 +17,9 @@ COPY --from=builder --chown=glowroot:root /tmp/glowroot-central /usr/share/glowr
 
 WORKDIR /usr/share/glowroot-central
 
+# need to give group write permission because OpenShift will ignore USER directives
+# and run the POD as a numbered userid which cannot possibly exist on the underlying physical host
+# but which is guaranteed to be a member of the "root" group
 RUN chmod g+w /usr/share/glowroot-central \
     chmod a+x /usr/local/bin/docker-entrypoint.sh \
     && chmod a+x /usr/local/bin/glowroot-central.sh \

--- a/central/Dockerfile
+++ b/central/Dockerfile
@@ -12,8 +12,11 @@ COPY docker-entrypoint.sh /usr/local/bin/
 COPY glowroot-central.sh /usr/local/bin/
 
 RUN useradd --no-log-init -r -g root glowroot
+
 COPY --from=builder --chown=glowroot:root /tmp/glowroot-central /usr/share/glowroot-central
+
 WORKDIR /usr/share/glowroot-central
+
 RUN chmod a+x /usr/local/bin/docker-entrypoint.sh \
     && chmod a+x /usr/local/bin/glowroot-central.sh \
     && sed -i 's/^cassandra.contactPoints=$/cassandra.contactPoints=cassandra/' /usr/share/glowroot-central/glowroot-central.properties \

--- a/central/Dockerfile
+++ b/central/Dockerfile
@@ -17,7 +17,8 @@ COPY --from=builder --chown=glowroot:root /tmp/glowroot-central /usr/share/glowr
 
 WORKDIR /usr/share/glowroot-central
 
-RUN chmod a+x /usr/local/bin/docker-entrypoint.sh \
+RUN chmod g+w /usr/share/glowroot-central \
+    chmod a+x /usr/local/bin/docker-entrypoint.sh \
     && chmod a+x /usr/local/bin/glowroot-central.sh \
     && sed -i 's/^cassandra.contactPoints=$/cassandra.contactPoints=cassandra/' /usr/share/glowroot-central/glowroot-central.properties \
     && echo '\ncassandra.symmetricEncryptionKey=' >> /usr/share/glowroot-central/glowroot-central.properties

--- a/central/Dockerfile
+++ b/central/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /usr/share/glowroot-central
 # and run the POD as a numbered userid which cannot possibly exist on the underlying physical host
 # but which is guaranteed to be a member of the "root" group
 RUN chmod g+w /usr/share/glowroot-central \
-    chmod a+x /usr/local/bin/docker-entrypoint.sh \
+    && chmod a+x /usr/local/bin/docker-entrypoint.sh \
     && chmod a+x /usr/local/bin/glowroot-central.sh \
     && sed -i 's/^cassandra.contactPoints=$/cassandra.contactPoints=cassandra/' /usr/share/glowroot-central/glowroot-central.properties \
     && echo '\ncassandra.symmetricEncryptionKey=' >> /usr/share/glowroot-central/glowroot-central.properties


### PR DESCRIPTION
My sysadmin kindly launched the Glowroot POD in debug mode.

The following was observed:

```
# ls -ld /usr/share/glowroot-central
drwxr-xr-x. 1 glowroot root 32 May 27 08:41 /usr/share/glowroot-central
```

This finally shows, conclusively, that /usr/share/glowroot-central can be written to by user "glowroot" but not by any other user which happens to be a member of the "root" group.

OpenShift will ignore USER directives, and run the POD as a numbered userid which cannot possibly exist on the underlying physical host but which is guarranteed to be a member of the "root" group.

This PR ascribes g+w permission to the /usr/share/glowroot-central directory before sed attempts to open its temporary file in that location.


