### PR TITLE
Fix #949 by using PathPatternsRequestCondition instead of PatternsReq…

### DIFF
--- a/agent/plugins/spring-plugin/src/main/java/org/glowroot/agent/plugin/spring/ControllerAspect.java
+++ b/agent/plugins/spring-plugin/src/main/java/org/glowroot/agent/plugin/spring/ControllerAspect.java
@@ -65,6 +65,17 @@ public class ControllerAspect {
                 + " getPatternsCondition()")
         @Nullable
         PatternsRequestCondition glowroot$getPatternsCondition();
+
+        @Shim("org.springframework.web.servlet.mvc.condition.PathPatternsRequestCondition"
+                + " getPathPatternsCondition()")
+        @Nullable
+        PathPatternsRequestCondition glowroot$getPathPatternsCondition();
+    }
+
+    @Shim("org.springframework.web.servlet.mvc.condition.PathPatternsRequestCondition")
+    public interface PathPatternsRequestCondition {
+        @Nullable
+        Set<String> getPatternValues();
     }
 
     @Shim("org.springframework.web.servlet.mvc.condition.PatternsRequestCondition")
@@ -140,18 +151,12 @@ public class ControllerAspect {
             if (!(mapping instanceof RequestMappingInfo)) {
                 return;
             }
-            PatternsRequestCondition patternCondition =
-                    ((RequestMappingInfo) mapping).glowroot$getPatternsCondition();
-            if (patternCondition == null) {
-                return;
-            }
-            Set<String> patterns = patternCondition.getPatterns();
-            if (patterns == null || patterns.isEmpty()) {
+            String pattern = getPattern((RequestMappingInfo) mapping);
+            if (pattern == null) {
                 return;
             }
             String prefix = getServletPath(context.getServletRequestInfo());
-            String pattern = patterns.iterator().next();
-            if (pattern == null || pattern.isEmpty()) {
+            if (pattern.isEmpty()) {
                 context.setTransactionName(prefix, Priority.CORE_PLUGIN);
                 return;
             }
@@ -375,5 +380,27 @@ public class ControllerAspect {
         } else {
             return servletRequestInfo.getContextPath() + servletRequestInfo.getServletPath();
         }
+    }
+
+    private static String getPattern(RequestMappingInfo mapping) {
+        PatternsRequestCondition patternCondition =
+                mapping.glowroot$getPatternsCondition();
+        if (patternCondition != null) {
+            Set<String> patterns = patternCondition.getPatterns();
+            if (patterns == null || patterns.isEmpty()) {
+                return null;
+            }
+            return patterns.iterator().next();
+        }
+        PathPatternsRequestCondition pathPatternCondition =
+                mapping.glowroot$getPathPatternsCondition();
+        if (pathPatternCondition == null) {
+            return null;
+        }
+        Set<String> patterns = pathPatternCondition.getPatternValues();
+        if (patterns == null || patterns.isEmpty()) {
+            return null;
+        }
+        return patterns.iterator().next();
     }
 }


### PR DESCRIPTION
This is my fix when using Spring 5.3 only,
As Spring 5.3 does not use PatternsCondition by default anymore, 
Request using PathVariable won't be group under the same TransactionName, and it will generate a lot more of worload for aggregating / querying ...


Not sure if it is possible to have retro-compatibility with spring prior to 5.3, as we need to use the `PathPatternsRequestCondition`, and that was introduce in 5.3.

Can we use shim on not existing fields if we do not invoke them?
Maybe add a parameter in spring plugin?