### PR TITLE
fix(sec): upgrade org.springframework:spring-web to 5.3.7

### DIFF
--- a/agent/benchmarks/pom.xml
+++ b/agent/benchmarks/pom.xml
@@ -37,7 +37,7 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
       <!-- Spring 5+ requires Java 8+ -->
-      <version>4.3.26.RELEASE</version>
+      <version>5.3.7</version>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>

--- a/agent/plugins/servlet-plugin/pom.xml
+++ b/agent/plugins/servlet-plugin/pom.xml
@@ -74,7 +74,7 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
       <!-- Spring 5+ requires Java 8+ -->
-      <version>4.3.26.RELEASE</version>
+      <version>5.3.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-web 4.3.26.RELEASE
- [CVE-2020-5421](https://www.oscs1024.com/hd/CVE-2020-5421)


### What did I do？
Upgrade org.springframework:spring-web from 4.3.26.RELEASE to 5.3.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS