### PR TITLE
Add in waitForContainerToCreatePlatform... wildfly bootable jar main class

### DIFF
--- a/agent/core/src/main/java/org/glowroot/agent/util/LazyPlatformMBeanServer.java
+++ b/agent/core/src/main/java/org/glowroot/agent/util/LazyPlatformMBeanServer.java
@@ -109,6 +109,7 @@ public class LazyPlatformMBeanServer {
 
     private LazyPlatformMBeanServer(@Nullable String mainClass) {
         boolean jbossModules = "org.jboss.modules.Main".equals(mainClass);
+        boolean wildflyBootable = "org.wildfly.core.jar.boot.Main".equals(mainClass);
         boolean wildflySwarm = "org.wildfly.swarm.bootstrap.Main".equals(mainClass);
         boolean oldJBoss = "org.jboss.Main".equals(mainClass);
         boolean glassfish = "com.sun.enterprise.glassfish.bootstrap.ASMain".equals(mainClass)
@@ -116,7 +117,7 @@ public class LazyPlatformMBeanServer {
         boolean weblogic = "weblogic.Server".equals(mainClass);
         boolean websphere = "com.ibm.wsspi.bootstrap.WSPreLauncher".equals(mainClass);
         waitForContainerToCreatePlatformMBeanServer =
-                jbossModules || wildflySwarm || oldJBoss || glassfish || weblogic || websphere;
+                jbossModules || wildflyBootable || wildflySwarm || oldJBoss || glassfish || weblogic || websphere;
         needsManualPatternMatching = oldJBoss;
     }
 


### PR DESCRIPTION
This simple PR enable run of glowroot agent on wildfly bootable jars (https://docs.wildfly.org/bootablejar/  -> https://mvnrepository.com/artifact/org.wildfly.core/wildfly-jar-boot).
Tested with:
org.wildfly.plugins:wildfly-jar-maven-plugin:8.0.1.Final
feature pack location: wildfly@maven(org.jboss.universe:community-universe)#26.1.2.Final
through jib image distroless/java17-debian11:latest

Thanks four your great work on glowroot!