### PR TITLE
Upgrade moment js to newer version

### DIFF
--- a/ui/bower.json
+++ b/ui/bower.json
@@ -20,7 +20,7 @@
     "fontawesome": "5.6.3",
     "handlebars": "4.0.12",
     "jquery": "3.3.1",
-    "moment": "2.23.0",
+    "moment": "2.29.4",
     "moment-timezone": "0.5.23",
     "popper.js": "1.14.6",
     "sequeljs": "trask/sequeljs#glowroot-0.13.4",


### PR DESCRIPTION
Moment.js version 2.23.0 used in glowroot is affected to 2 vulnerabilities:
- [CVE-2022-24785](https://nvd.nist.gov/vuln/detail/CVE-2022-24785), solved from version 2.29.2
- [CVE-2022-31129](https://nvd.nist.gov/vuln/detail/CVE-2022-31129), solved from version 2.29.4