### PR TITLE
Fix: do not weave jdk/internal/reflect/Generated*

### DIFF
--- a/agent/core/src/main/java/org/glowroot/agent/weaving/WeavingClassFileTransformer.java
+++ b/agent/core/src/main/java/org/glowroot/agent/weaving/WeavingClassFileTransformer.java
@@ -129,6 +129,13 @@ public class WeavingClassFileTransformer implements ClassFileTransformer {
             // sun/reflect/GeneratedMethodAccessor..
             return true;
         }
+        if (className.startsWith("jdk/internal/reflect/Generated")) {
+            // optimization, no need to try to weave the many classes generated for reflection:
+            // jdk/internal/reflect/GeneratedSerializationConstructorAccessor..
+            // jdk/internal/reflect/GeneratedConstructorAccessor..
+            // jdk/internal/reflect/GeneratedMethodAccessor..
+            return true;
+        }
         // proxies under JDK 7+ start with com/sun/proxy/$Proxy
         if (className.matches("^jdk/proxy\\d+/\\$Proxy.*") || className.startsWith("com/sun/proxy/$Proxy")) {
             // optimization, especially for jdbc plugin to avoid weaving proxy wrappers when dealing


### PR DESCRIPTION
Hi @trask 

with the new version of jdk, classes `sun/reflect/Generated` has been moved to `jdk/internal/reflect/Generated`.

This very simple PR aims at not weaving these classes.