### PR TITLE
Fix: provides support for Jakarta.* packages

### DIFF
--- a/agent/core/src/main/java/org/glowroot/agent/init/PreCheckLoadedClasses.java
+++ b/agent/core/src/main/java/org/glowroot/agent/init/PreCheckLoadedClasses.java
@@ -67,7 +67,11 @@ public class PreCheckLoadedClasses {
     private static boolean isImportantRunnableOrCallable(String className, Class<?> clazz) {
         return className.startsWith("java.util.concurrent.") && !clazz.isInterface()
                 && (Runnable.class.isAssignableFrom(clazz)
-                        || Callable.class.isAssignableFrom(clazz));
+                        || Callable.class.isAssignableFrom(clazz))
+                // it seems that java 19+ loads very early the ForkJoinWorkerThread class
+                // maybe because of the virtual threads feature
+                // see https://levelup.gitconnected.com/java-virtual-threads-millions-of-threads-within-grasp-e0a4d26548ba
+                && !className.equals("java.util.concurrent.ForkJoinWorkerThread");
     }
 
     private static boolean isShaded() {

--- a/agent/core/src/main/java/org/glowroot/agent/weaving/AnalyzedWorld.java
+++ b/agent/core/src/main/java/org/glowroot/agent/weaving/AnalyzedWorld.java
@@ -536,7 +536,8 @@ public class AnalyzedWorld {
         }
         boolean ejbRemote = false;
         for (Annotation annotation : clazz.getDeclaredAnnotations()) {
-            if (annotation.annotationType().getName().equals("javax.ejb.Remote")) {
+            if (annotation.annotationType().getName().equals("javax.ejb.Remote") ||
+                    annotation.annotationType().getName().equals("jakarta.ejb.Remote")) {
                 ejbRemote = true;
                 break;
             }

--- a/agent/core/src/main/java/org/glowroot/agent/weaving/ClassAnalyzer.java
+++ b/agent/core/src/main/java/org/glowroot/agent/weaving/ClassAnalyzer.java
@@ -105,9 +105,9 @@ class ClassAnalyzer {
         boolean ejbRemote = false;
         boolean ejbStateless = false;
         for (String annotation : thinClass.annotations()) {
-            if (annotation.equals("Ljavax/ejb/Remote;")) {
+            if (annotation.equals("Ljavax/ejb/Remote;") || annotation.equals("Ljakarta/ejb/Remote;")) {
                 ejbRemote = true;
-            } else if (annotation.equals("Ljavax/ejb/Stateless;")) {
+            } else if (annotation.equals("Ljavax/ejb/Stateless;") || annotation.equals("Ljakarta/ejb/Stateless;")) {
                 ejbStateless = true;
             }
         }

--- a/agent/core/src/main/java/org/glowroot/agent/weaving/ThinClassVisitor.java
+++ b/agent/core/src/main/java/org/glowroot/agent/weaving/ThinClassVisitor.java
@@ -59,7 +59,7 @@ class ThinClassVisitor extends ClassVisitor {
         thinClassBuilder.addAnnotations(descriptor);
         if (descriptor.equals("Lorg/glowroot/agent/plugin/api/weaving/Pointcut;")) {
             return new PointcutAnnotationVisitor();
-        } else if (descriptor.equals("Ljavax/ejb/Remote;")) {
+        } else if (descriptor.equals("Ljavax/ejb/Remote;") || descriptor.equals("Ljakarta/ejb/Remote;")) {
             return new RemoteAnnotationVisitor();
         } else {
             return null;

--- a/agent/dist/pom.xml
+++ b/agent/dist/pom.xml
@@ -104,6 +104,11 @@
     </dependency>
     <dependency>
       <groupId>org.glowroot</groupId>
+      <artifactId>glowroot-agent-jakarta-servlet-plugin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glowroot</groupId>
       <artifactId>glowroot-agent-java-http-server-plugin</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/agent/plugins/ejb-plugin/src/main/resources/META-INF/glowroot.plugin.json
+++ b/agent/plugins/ejb-plugin/src/main/resources/META-INF/glowroot.plugin.json
@@ -3,8 +3,8 @@
   "id": "ejb",
   "instrumentation": [
     {
-      "classAnnotation": "javax.ejb.Singleton",
-      "methodAnnotation": "javax.ejb.Timeout|javax.ejb.Schedule|javax.ejb.Schedules",
+      "classAnnotation": "javax.ejb.Singleton|jakarta.ejb.Singleton",
+      "methodAnnotation": "javax.ejb.Timeout|jakarta.ejb.Timeout|javax.ejb.Schedule|jakarta.ejb.Schedule|javax.ejb.Schedules|jakarta.ejb.Schedules",
       "methodParameterTypes": [
         ".."
       ],

--- a/agent/plugins/jakarta-servlet-plugin/pom.xml
+++ b/agent/plugins/jakarta-servlet-plugin/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.glowroot</groupId>
+    <artifactId>glowroot-parent</artifactId>
+    <version>0.14.0-beta.4-SNAPSHOT</version>
+    <relativePath>../../..</relativePath>
+  </parent>
+
+  <artifactId>glowroot-agent-jakarta-servlet-plugin</artifactId>
+
+  <name>Glowroot Agent Jakarta Servlet Plugin</name>
+  <description>Glowroot Agent Jakarta Servlet Plugin</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.glowroot</groupId>
+      <artifactId>glowroot-agent-plugin-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>5.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>auto-activated-test-unshaded</id>
+      <activation>
+        <property>
+          <name>!glowroot.test.shaded</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.glowroot</groupId>
+          <artifactId>glowroot-agent-it-harness-unshaded</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>auto-activated-test-shaded</id>
+      <activation>
+        <property>
+          <name>glowroot.test.shaded</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.glowroot</groupId>
+          <artifactId>glowroot-agent-it-harness</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <!-- exclusion is needed due to https://issues.apache.org/jira/browse/MSHADE-206 -->
+              <groupId>org.glowroot</groupId>
+              <artifactId>glowroot-agent-it-harness-unshaded</artifactId>
+            </exclusion>
+            <exclusion>
+              <!-- exclusion is needed due to https://issues.apache.org/jira/browse/MSHADE-206 -->
+              <groupId>org.glowroot</groupId>
+              <artifactId>glowroot-agent-core</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+</project>

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/AsyncServletAspect.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/AsyncServletAspect.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet;
+
+import org.glowroot.agent.plugin.api.ThreadContext;
+import org.glowroot.agent.plugin.api.weaving.*;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.ServletRequest;
+
+public class AsyncServletAspect {
+
+    static final String GLOWROOT_AUX_CONTEXT_REQUEST_ATTRIBUTE = "glowroot$auxContext";
+
+    @Pointcut(className = "jakarta.servlet.ServletRequest", methodName = "startAsync",
+            methodParameterTypes = {".."})
+    public static class StartAsyncAdvice {
+        @OnReturn
+        public static void onReturn(@BindReturn AsyncContext asyncContext,
+                final ThreadContext context) {
+            context.setTransactionAsync();
+            asyncContext.addListener(new AsyncListener() {
+                @Override
+                public void onComplete(AsyncEvent event) {
+                    context.setTransactionAsyncComplete();
+                }
+                @Override
+                public void onTimeout(AsyncEvent event) {
+                    Throwable throwable = event.getThrowable();
+                    if (throwable != null) {
+                        context.setTransactionError(throwable);
+                    }
+                    context.setTransactionAsyncComplete();
+                }
+                @Override
+                public void onError(AsyncEvent event) {
+                    Throwable throwable = event.getThrowable();
+                    if (throwable != null) {
+                        context.setTransactionError(throwable);
+                    }
+                    context.setTransactionAsyncComplete();
+                }
+                @Override
+                public void onStartAsync(AsyncEvent event) {
+                    AsyncContext asyncContext = event.getAsyncContext();
+                    if (asyncContext != null) {
+                        asyncContext.addListener(this);
+                    }
+                }
+            });
+        }
+    }
+
+    // IMPORTANT complete is not called if client disconnects, but it's still useful to capture for
+    // normal requests since it is called from an auxiliary thread, and by calling
+    // setTransactionAsyncComplete() first from the auxiliary thread, the transaction will wait to
+    // complete until the auxiliary thread completes, and won't leave behind "this auxiliary thread
+    // was still running when the transaction ended" trace entry
+    @Pointcut(className = "jakarta.servlet.AsyncContext", methodName = "complete",
+            methodParameterTypes = {})
+    public static class CompleteAdvice {
+        // using @OnBefore instead of @OnReturn since it is during complete() that AsyncEvent is
+        // fired, and want the setTransactionAsyncComplete() in this (auxiliary) thread to win
+        @OnBefore
+        public static void onBefore(ThreadContext context) {
+            context.setTransactionAsyncComplete();
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.AsyncContext", methodName = "dispatch",
+            methodParameterTypes = {".."}, nestingGroup = "servlet-dispatch")
+    public static class DispatchAdvice {
+        @OnBefore
+        public static void onBefore(ThreadContext context,
+                @BindReceiver AsyncContext asyncContext) {
+            ServletRequest request = asyncContext.getRequest();
+            if (request == null) {
+                return;
+            }
+            request.setAttribute(GLOWROOT_AUX_CONTEXT_REQUEST_ATTRIBUTE,
+                    context.createAuxThreadContext());
+        }
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/ContainerStartup.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/ContainerStartup.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet;
+
+import org.glowroot.agent.plugin.api.*;
+import org.glowroot.agent.plugin.api.ThreadContext.Priority;
+import org.glowroot.agent.plugin.api.checker.Nullable;
+
+import java.lang.management.ManagementFactory;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class ContainerStartup {
+
+    private static final Logger logger = Logger.getLogger(ContainerStartup.class);
+
+    private ContainerStartup() {}
+
+    static TraceEntry onBeforeCommon(OptionalThreadContext context, @Nullable String path,
+            TimerName timerName) {
+        initPlatformMBeanServer();
+        String transactionName;
+        if (path == null || path.isEmpty()) {
+            // root context path is empty "", but makes more sense to display "/"
+            transactionName = "Servlet context: /";
+        } else {
+            transactionName = "Servlet context: " + path;
+        }
+        TraceEntry traceEntry = context.startTransaction("Startup", transactionName,
+                MessageSupplier.create(transactionName), timerName);
+        context.setTransactionSlowThreshold(0, MILLISECONDS, Priority.CORE_PLUGIN);
+        return traceEntry;
+    }
+
+    static void initPlatformMBeanServer() {
+        // make sure the platform mbean server gets created so that it can then be retrieved by
+        // LazyPlatformMBeanServer which may be waiting for it to be created (the current
+        // thread context class loader should have access to the platform mbean server that is set
+        // via the javax.management.builder.initial system property)
+        try {
+            ManagementFactory.getPlatformMBeanServer();
+        } catch (Throwable t) {
+            logger.error("could not create platform mbean server: {}", t.getMessage(), t);
+        }
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/DetailCapture.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/DetailCapture.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet;
+
+import org.glowroot.agent.plugin.api.checker.Nullable;
+import org.glowroot.agent.plugin.api.util.ImmutableList;
+import org.glowroot.agent.plugin.api.util.ImmutableMap;
+import org.glowroot.agent.plugin.jakartaservlet._.RequestHostAndPortDetail;
+import org.glowroot.agent.plugin.jakartaservlet._.RequestInvoker;
+import org.glowroot.agent.plugin.jakartaservlet._.ServletPluginProperties;
+import org.glowroot.agent.plugin.jakartaservlet._.Strings;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.*;
+import java.util.regex.Pattern;
+
+// shallow copies are necessary because request may not be thread safe, which may affect ability
+// to see detail from active traces
+//
+// shallow copies are also necessary because servlet container may clear out the objects after the
+// request is complete (e.g. tomcat does this) in order to reuse them, in which case this detail
+// would need to be captured synchronously at end of request anyways (although then it could be
+// captured only if trace met threshold for storage...)
+public class DetailCapture {
+
+    private DetailCapture() {}
+
+    public static Map<String, Object> captureRequestParameters(
+            Map</*@Nullable*/ String, ?> requestParameters) {
+        List<Pattern> capturePatterns = ServletPluginProperties.captureRequestParameters();
+        Map<String, Object> map = new HashMap<String, Object>();
+        for (Map.Entry</*@Nullable*/ String, ?> entry : requestParameters.entrySet()) {
+            String name = entry.getKey();
+            if (name == null) {
+                continue;
+            }
+            // converted to lower case for case-insensitive matching (patterns are lower case)
+            String keyLowerCase = name.toLowerCase(Locale.ENGLISH);
+            if (!matchesOneOf(keyLowerCase, capturePatterns)) {
+                continue;
+            }
+            Object value = entry.getValue();
+            if (value instanceof String[]) {
+                set(map, name, (String[]) value);
+            }
+        }
+        return ImmutableMap.copyOf(map);
+    }
+
+    public static Map<String, Object> captureRequestParameters(HttpServletRequest request) {
+        Enumeration<? extends /*@Nullable*/ Object> e = request.getParameterNames();
+        if (e == null) {
+            return Collections.emptyMap();
+        }
+        List<Pattern> capturePatterns = ServletPluginProperties.captureRequestParameters();
+        List<Pattern> maskPatterns = ServletPluginProperties.maskRequestParameters();
+        Map<String, Object> map = new HashMap<String, Object>();
+        while (e.hasMoreElements()) {
+            Object nameObj = e.nextElement();
+            if (nameObj == null) {
+                continue;
+            }
+            if (!(nameObj instanceof String)) {
+                continue;
+            }
+            String name = (String) nameObj;
+            // converted to lower case for case-insensitive matching (patterns are lower case)
+            String keyLowerCase = name.toLowerCase(Locale.ENGLISH);
+            if (!matchesOneOf(keyLowerCase, capturePatterns)) {
+                continue;
+            }
+            if (matchesOneOf(keyLowerCase, maskPatterns)) {
+                map.put(name, "****");
+                continue;
+            }
+            @Nullable
+            String[] values = request.getParameterValues(name);
+            if (values != null) {
+                set(map, name, values);
+            }
+        }
+        return ImmutableMap.copyOf(map);
+    }
+
+    private static void set(Map<String, Object> map, String name, /*@Nullable*/ String[] values) {
+        if (values.length == 1) {
+            String value = values[0];
+            if (value != null) {
+                map.put(name, value);
+            }
+        } else {
+            List</*@Nullable*/ String> list =
+                    new ArrayList</*@Nullable*/ String>(values.length);
+            Collections.addAll(list, values);
+            map.put(name, list);
+        }
+    }
+
+    public static Map<String, Object> captureRequestHeaders(HttpServletRequest request) {
+        List<Pattern> capturePatterns = ServletPluginProperties.captureRequestHeaders();
+        if (capturePatterns.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Enumeration</*@Nullable*/ String> headerNames = request.getHeaderNames();
+        if (headerNames == null) {
+            return Collections.emptyMap();
+        }
+        for (Enumeration</*@Nullable*/ String> e = headerNames; e.hasMoreElements();) {
+            String name = e.nextElement();
+            if (name == null) {
+                continue;
+            }
+            // converted to lower case for case-insensitive matching (patterns are lower case)
+            String keyLowerCase = name.toLowerCase(Locale.ENGLISH);
+            if (!matchesOneOf(keyLowerCase, capturePatterns)) {
+                continue;
+            }
+            Enumeration</*@Nullable*/ String> values = request.getHeaders(name);
+            if (values != null) {
+                captureRequestHeader(name, values, requestHeaders);
+            }
+        }
+        return ImmutableMap.copyOf(requestHeaders);
+    }
+
+    public static @Nullable RequestHostAndPortDetail captureRequestHostAndPortDetail(
+            HttpServletRequest request, RequestInvoker requestInvoker) {
+        if (ServletPluginProperties.captureSomeRequestHostAndPortDetail()) {
+            RequestHostAndPortDetail requestHostAndPortDetail = new RequestHostAndPortDetail();
+            if (ServletPluginProperties.captureRequestRemoteAddress()) {
+                requestHostAndPortDetail.remoteAddress = request.getRemoteAddr();
+            }
+            if (ServletPluginProperties.captureRequestRemoteHostname()) {
+                requestHostAndPortDetail.remoteHostname = request.getRemoteHost();
+            }
+            if (ServletPluginProperties.captureRequestRemotePort()) {
+                requestHostAndPortDetail.remotePort = requestInvoker.getRemotePort(request);
+            }
+            if (ServletPluginProperties.captureRequestLocalAddress()) {
+                requestHostAndPortDetail.localAddress = requestInvoker.getLocalAddr(request);
+            }
+            if (ServletPluginProperties.captureRequestLocalHostname()) {
+                requestHostAndPortDetail.localHostname = requestInvoker.getLocalName(request);
+            }
+            if (ServletPluginProperties.captureRequestLocalPort()) {
+                requestHostAndPortDetail.localPort = requestInvoker.getLocalPort(request);
+            }
+            if (ServletPluginProperties.captureRequestServerHostname()) {
+                requestHostAndPortDetail.serverHostname = request.getServerName();
+            }
+            if (ServletPluginProperties.captureRequestServerPort()) {
+                requestHostAndPortDetail.serverPort = request.getServerPort();
+            }
+            return requestHostAndPortDetail;
+        } else {
+            // optimized for common case
+            return null;
+        }
+    }
+
+    public static boolean matchesOneOf(String key, List<Pattern> patterns) {
+        for (Pattern pattern : patterns) {
+            if (pattern.matcher(key).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void captureRequestHeader(String name, Enumeration</*@Nullable*/ String> values,
+            Map<String, Object> requestHeaders) {
+        if (!values.hasMoreElements()) {
+            requestHeaders.put(name, "");
+        } else {
+            String value = values.nextElement();
+            if (!values.hasMoreElements()) {
+                requestHeaders.put(name, Strings.nullToEmpty(value));
+            } else {
+                List<String> list = new ArrayList<String>();
+                list.add(Strings.nullToEmpty(value));
+                while (values.hasMoreElements()) {
+                    list.add(Strings.nullToEmpty(values.nextElement()));
+                }
+                requestHeaders.put(name, ImmutableList.copyOf(list));
+            }
+        }
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/HttpSessions.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/HttpSessions.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet;
+
+import org.glowroot.agent.plugin.api.checker.Nullable;
+import org.glowroot.agent.plugin.api.util.Beans;
+import org.glowroot.agent.plugin.api.util.ImmutableMap;
+import org.glowroot.agent.plugin.jakartaservlet._.ServletPluginProperties;
+import org.glowroot.agent.plugin.jakartaservlet._.ServletPluginProperties.SessionAttributePath;
+import org.glowroot.agent.plugin.jakartaservlet._.Strings;
+
+import jakarta.servlet.http.HttpSession;
+import java.util.*;
+
+public class HttpSessions {
+
+    private HttpSessions() {}
+
+    public static Map<String, String> getSessionAttributes(HttpSession session) {
+        List<SessionAttributePath> attributePaths =
+                ServletPluginProperties.captureSessionAttributePaths();
+        if (attributePaths.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> captureMap = new HashMap<String, String>();
+        // dump only http session attributes in list
+        for (SessionAttributePath attributePath : attributePaths) {
+            if (attributePath.isAttributeNameWildcard()) {
+                captureAllSessionAttributes(session, captureMap);
+            } else if (attributePath.isWildcard()) {
+                captureWildcardPath(session, captureMap, attributePath);
+            } else {
+                captureNonWildcardPath(session, captureMap, attributePath);
+            }
+        }
+        return ImmutableMap.copyOf(captureMap);
+    }
+
+    public static @Nullable Object getSessionAttribute(HttpSession session,
+            SessionAttributePath attributePath) {
+        if (attributePath.isSessionId()) {
+            return session.getId();
+        }
+        Object attributeValue = session.getAttribute(attributePath.getAttributeName());
+        return getSessionAttribute(attributeValue, attributePath);
+    }
+
+    public static @Nullable Object getSessionAttribute(@Nullable Object attributeValue,
+            SessionAttributePath attributePath) {
+        List<String> nestedPath = attributePath.getNestedPath();
+        if (nestedPath.isEmpty()) {
+            return attributeValue;
+        } else {
+            try {
+                return Beans.value(attributeValue, nestedPath);
+            } catch (Exception e) {
+                return "<error evaluating: " + e + ">";
+            }
+        }
+    }
+
+    private static void captureAllSessionAttributes(HttpSession session,
+            Map<String, String> captureMap) {
+        Enumeration<? extends /*@Nullable*/ Object> e = session.getAttributeNames();
+        if (e == null) {
+            return;
+        }
+        while (e.hasMoreElements()) {
+            String attributeName = (String) e.nextElement();
+            if (attributeName == null) {
+                continue;
+            }
+            if (attributeName.equals(ServletPluginProperties.HTTP_SESSION_ID_ATTR)) {
+                captureMap.put(attributeName, Strings.nullToEmpty(session.getId()));
+                continue;
+            }
+            Object valueObj = session.getAttribute(attributeName);
+            if (valueObj == null) {
+                // value shouldn't be null, but its (remotely) possible that a concurrent
+                // request for the same session just removed the attribute
+                continue;
+            }
+            String value;
+            try {
+                value = Strings.nullToEmpty(valueObj.toString());
+            } catch (Exception f) {
+                value = "<error evaluating: " + f + ">";
+            }
+            captureMap.put(attributeName, value);
+        }
+    }
+
+    private static void captureWildcardPath(HttpSession session, Map<String, String> captureMap,
+            SessionAttributePath attributePath) {
+        Object value = getSessionAttribute(session, attributePath);
+        if (value instanceof Map<?, ?>) {
+            String fullPath = attributePath.getFullPath();
+            for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+                Object val = entry.getValue();
+                captureMap.put(fullPath + "." + entry.getKey(),
+                        val == null ? "" : Strings.nullToEmpty(val.toString()));
+            }
+        } else if (value != null) {
+            String fullPath = attributePath.getFullPath();
+            for (Map.Entry<String, String> entry : Beans.propertiesAsText(value).entrySet()) {
+                captureMap.put(fullPath + "." + entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    private static void captureNonWildcardPath(HttpSession session, Map<String, String> captureMap,
+            SessionAttributePath attributePath) {
+        Object value = getSessionAttribute(session, attributePath);
+        if (value != null) {
+            captureMap.put(attributePath.getFullPath(), Strings.nullToEmpty(value.toString()));
+        }
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/RequestDispatcherAspect.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/RequestDispatcherAspect.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet;
+
+import org.glowroot.agent.plugin.api.*;
+import org.glowroot.agent.plugin.api.checker.Nullable;
+import org.glowroot.agent.plugin.api.weaving.*;
+
+public class RequestDispatcherAspect {
+
+    // the field and method names are verbose since they will be mixed in to existing classes
+    @Mixin("jakarta.servlet.RequestDispatcher")
+    public abstract static class RequestDispatcherImpl implements RequestDispatcherMixin {
+
+        private transient @Nullable String glowroot$path;
+
+        @Override
+        public @Nullable String glowroot$getPath() {
+            return glowroot$path;
+        }
+
+        @Override
+        public void glowroot$setPath(@Nullable String path) {
+            glowroot$path = path;
+        }
+    }
+
+    // the method names are verbose since they will be mixed in to existing classes
+    public interface RequestDispatcherMixin {
+
+        @Nullable
+        String glowroot$getPath();
+
+        void glowroot$setPath(@Nullable String path);
+    }
+
+    @Pointcut(className = "jakarta.servlet.ServletRequest|jakarta.servlet.ServletContext",
+            methodName = "getRequestDispatcher|getNamedDispatcher",
+            methodParameterTypes = {"java.lang.String"}, nestingGroup = "servlet-inner-call")
+    public static class GetParameterAdvice {
+        @OnReturn
+        public static void onReturn(@BindReturn @Nullable RequestDispatcherMixin requestDispatcher,
+                @BindParameter @Nullable String path) {
+            if (requestDispatcher == null) {
+                // seems nothing sensible to do here other than ignore
+                return;
+            }
+            requestDispatcher.glowroot$setPath(path);
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.RequestDispatcher", methodName = "forward|include",
+            methodParameterTypes = {"jakarta.servlet.ServletRequest",
+                    "jakarta.servlet.ServletResponse"},
+            nestingGroup = "servlet-dispatch", timerName = "servlet dispatch")
+    public static class DispatchAdvice {
+        private static final TimerName timerName = Agent.getTimerName(DispatchAdvice.class);
+        @OnBefore
+        public static TraceEntry onBefore(ThreadContext context,
+                @BindReceiver RequestDispatcherMixin requestDispatcher) {
+            return context.startTraceEntry(MessageSupplier.create("servlet dispatch: {}",
+                    requestDispatcher.glowroot$getPath()), timerName);
+        }
+        @OnReturn
+        public static void onReturn(@BindTraveler TraceEntry traceEntry) {
+            traceEntry.end();
+        }
+        @OnThrow
+        public static void onThrow(@BindThrowable Throwable t,
+                @BindTraveler TraceEntry traceEntry) {
+            traceEntry.endWithError(t);
+        }
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/RequestParameterAspect.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/RequestParameterAspect.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2011-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet;
+
+import org.glowroot.agent.plugin.api.Logger;
+import org.glowroot.agent.plugin.api.ThreadContext;
+import org.glowroot.agent.plugin.api.weaving.BindClassMeta;
+import org.glowroot.agent.plugin.api.weaving.BindReceiver;
+import org.glowroot.agent.plugin.api.weaving.OnReturn;
+import org.glowroot.agent.plugin.api.weaving.Pointcut;
+import org.glowroot.agent.plugin.jakartaservlet._.RequestClassMeta;
+import org.glowroot.agent.plugin.jakartaservlet._.ServletMessageSupplier;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+public class RequestParameterAspect {
+
+    private static final Logger logger = Logger.getLogger(RequestParameterAspect.class);
+
+    @Pointcut(className = "jakarta.servlet.ServletRequest", methodName = "getParameter*",
+            methodParameterTypes = {".."}, nestingGroup = "servlet-inner-call")
+    public static class GetParameterAdvice {
+        @OnReturn
+        public static void onReturn(ThreadContext context, @BindReceiver Object req,
+                @BindClassMeta RequestClassMeta requestClassMeta) {
+            if (!(req instanceof HttpServletRequest)) {
+                return;
+            }
+            HttpServletRequest request = (HttpServletRequest) req;
+            // only now is it safe to get parameters (if parameters are retrieved before this, it
+            // could prevent a servlet from choosing to read the underlying stream instead of using
+            // the getParameter* methods) see SRV.3.1.1 "When Parameters Are Available"
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier == null || messageSupplier.isRequestParametersCaptured()) {
+                return;
+            }
+            // the request is being traced and the parameter map hasn't been captured yet
+            captureRequestParameters(requestClassMeta, request, messageSupplier);
+        }
+
+        private static void captureRequestParameters(RequestClassMeta requestClassMeta,
+                HttpServletRequest request, ServletMessageSupplier messageSupplier) {
+            if (requestClassMeta.isBadParameterMapImplementation()) {
+                messageSupplier.setCaptureRequestParameters(
+                        DetailCapture.captureRequestParameters(request));
+                return;
+            }
+            Map</*@Nullable*/ String, ?> parameterMap;
+            try {
+                parameterMap = request.getParameterMap();
+            } catch (Exception e) {
+                // this is to handle at least one web container (ATG 9.4) which has a bad
+                // implementation of getParameterMap(), specifically in ATG's case
+                // atg.taglib.dspjsp.RequestWrapper delegates the other getParameter*() methods but
+                // it fails to delegate getParameterMap(), which then falls through to super class
+                // atg.servlet.MutableHttpServletRequest and generates a NullPointerException since
+                // the super class was not set up expecting the call
+
+                // log exception at debug level
+                logger.debug(e.getMessage(), e);
+                // set flag so don't keep generating/catching exception over and over
+                requestClassMeta.setBadParameterMapImplementation();
+                messageSupplier.setCaptureRequestParameters(
+                        DetailCapture.captureRequestParameters(request));
+                return;
+            }
+            if (parameterMap == null) {
+                return;
+            }
+            if (parameterMap.isEmpty()) {
+                // do not call setCaptureRequestParameters(), which will cause
+                // isRequestParametersCaptured() to return true and prevent further capture of
+                // request parameters, e.g. after a multipart/form-data request is wrapped by
+                // org.springframework.web.multipart.support.DefaultMultipartHttpServletRequest
+                return;
+            }
+            messageSupplier.setCaptureRequestParameters(
+                    DetailCapture.captureRequestParameters(parameterMap));
+        }
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/ResponseHeaderAspect.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/ResponseHeaderAspect.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet;
+
+import org.glowroot.agent.plugin.api.ThreadContext;
+import org.glowroot.agent.plugin.api.checker.Nullable;
+import org.glowroot.agent.plugin.api.weaving.*;
+import org.glowroot.agent.plugin.jakartaservlet._.ResponseInvoker;
+import org.glowroot.agent.plugin.jakartaservlet._.ServletMessageSupplier;
+import org.glowroot.agent.plugin.jakartaservlet._.ServletPluginProperties;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+public class ResponseHeaderAspect {
+
+    @Pointcut(className = "jakarta.servlet.ServletResponse", methodName = "setContentLength",
+            methodParameterTypes = {"int"}, nestingGroup = "servlet-inner-call")
+    public static class SetContentLengthAdvice {
+        @IsEnabled
+        public static boolean isEnabled() {
+            // good to short-cut advice if no response headers need to be captured
+            return ServletPluginProperties.captureResponseHeadersNonEmpty();
+        }
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindParameter int value) {
+            if (!ServletPluginProperties.captureContentLengthResponseHeader()) {
+                return;
+            }
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                messageSupplier.setResponseIntHeader("Content-Length", value);
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.ServletResponse", methodName = "setContentLengthLong",
+            methodParameterTypes = {"long"}, nestingGroup = "servlet-inner-call")
+    public static class SetContentLengthLongAdvice {
+        @IsEnabled
+        public static boolean isEnabled() {
+            // good to short-cut advice if no response headers need to be captured
+            return ServletPluginProperties.captureResponseHeadersNonEmpty();
+        }
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindParameter long value) {
+            if (!ServletPluginProperties.captureContentLengthResponseHeader()) {
+                return;
+            }
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                messageSupplier.setResponseLongHeader("Content-Length", value);
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.ServletResponse", methodName = "setContentType",
+            methodParameterTypes = {"java.lang.String"}, nestingGroup = "servlet-inner-call")
+    public static class SetContentTypeAdvice {
+        @IsEnabled
+        public static boolean isEnabled() {
+            // good to short-cut advice if no response headers need to be captured
+            return ServletPluginProperties.captureResponseHeadersNonEmpty();
+        }
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindReceiver Object response,
+                @BindParameter @Nullable String value,
+                @BindClassMeta ResponseInvoker responseInvoker) {
+            if (value == null) {
+                // seems nothing sensible to do here other than ignore
+                return;
+            }
+            if (!ServletPluginProperties.captureContentTypeResponseHeader()) {
+                return;
+            }
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                if (responseInvoker.hasGetContentTypeMethod()) {
+                    String contentType = responseInvoker.getContentType(response);
+                    messageSupplier.setResponseHeader("Content-Type", contentType);
+                } else {
+                    messageSupplier.setResponseHeader("Content-Type", value);
+                }
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.ServletResponse", methodName = "setCharacterEncoding",
+            methodParameterTypes = {"java.lang.String"}, nestingGroup = "servlet-inner-call")
+    public static class SetCharacterEncodingAdvice {
+        @IsEnabled
+        public static boolean isEnabled() {
+            // good to short-cut advice if no response headers need to be captured
+            return ServletPluginProperties.captureResponseHeadersNonEmpty();
+        }
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindReceiver Object response,
+                @BindClassMeta ResponseInvoker responseInvoker) {
+            if (!ServletPluginProperties.captureContentTypeResponseHeader()) {
+                return;
+            }
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null && responseInvoker.hasGetContentTypeMethod()) {
+                String contentType = responseInvoker.getContentType(response);
+                messageSupplier.setResponseHeader("Content-Type", contentType);
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.ServletResponse", methodName = "setLocale",
+            methodParameterTypes = {"java.util.Locale"}, nestingGroup = "servlet-inner-call")
+    public static class SetLocaleAdvice {
+        @IsEnabled
+        public static boolean isEnabled() {
+            // good to short-cut advice if no response headers need to be captured
+            return ServletPluginProperties.captureResponseHeadersNonEmpty();
+        }
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindReceiver Object response,
+                @BindParameter @Nullable Locale locale,
+                @BindClassMeta ResponseInvoker responseInvoker) {
+            if (locale == null) {
+                // seems nothing sensible to do here other than ignore
+                return;
+            }
+            boolean captureContentLanguage =
+                    ServletPluginProperties.captureContentLanguageResponseHeader();
+            boolean captureContentType = ServletPluginProperties.captureContentTypeResponseHeader();
+            if (!captureContentLanguage && !captureContentType) {
+                return;
+            }
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                if (captureContentLanguage) {
+                    messageSupplier.setResponseHeader("Content-Language", locale.toString());
+                }
+                if (captureContentType && responseInvoker.hasGetContentTypeMethod()) {
+                    String contentType = responseInvoker.getContentType(response);
+                    messageSupplier.setResponseHeader("Content-Type", contentType);
+                }
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.http.HttpServletResponse", methodName = "setHeader",
+            methodParameterTypes = {"java.lang.String", "java.lang.String"},
+            nestingGroup = "servlet-inner-call")
+    public static class SetHeaderAdvice {
+        @IsEnabled
+        public static boolean isEnabled() {
+            // good to short-cut advice if no response headers need to be captured
+            return ServletPluginProperties.captureResponseHeadersNonEmpty();
+        }
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindParameter @Nullable String name,
+                @BindParameter @Nullable String value) {
+            if (name == null || value == null) {
+                // seems nothing sensible to do here other than ignore
+                return;
+            }
+            if (!captureResponseHeader(name)) {
+                return;
+            }
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                messageSupplier.setResponseHeader(name, value);
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.http.HttpServletResponse", methodName = "setDateHeader",
+            methodParameterTypes = {"java.lang.String", "long"},
+            nestingGroup = "servlet-inner-call")
+    public static class SetDateHeaderAdvice {
+        @IsEnabled
+        public static boolean isEnabled() {
+            // good to short-cut advice if no response headers need to be captured
+            return ServletPluginProperties.captureResponseHeadersNonEmpty();
+        }
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindParameter @Nullable String name,
+                @BindParameter long value) {
+            if (name == null) {
+                // seems nothing sensible to do here other than ignore
+                return;
+            }
+            if (!captureResponseHeader(name)) {
+                return;
+            }
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                messageSupplier.setResponseDateHeader(name, value);
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.http.HttpServletResponse", methodName = "setIntHeader",
+            methodParameterTypes = {"java.lang.String", "int"}, nestingGroup = "servlet-inner-call")
+    public static class SetIntHeaderAdvice {
+        @IsEnabled
+        public static boolean isEnabled() {
+            // good to short-cut advice if no response headers need to be captured
+            return ServletPluginProperties.captureResponseHeadersNonEmpty();
+        }
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindParameter @Nullable String name,
+                @BindParameter int value) {
+            if (name == null) {
+                // seems nothing sensible to do here other than ignore
+                return;
+            }
+            if (!captureResponseHeader(name)) {
+                return;
+            }
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                messageSupplier.setResponseIntHeader(name, value);
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.http.HttpServletResponse", methodName = "addHeader",
+            methodParameterTypes = {"java.lang.String", "java.lang.String"},
+            nestingGroup = "servlet-inner-call")
+    public static class AddHeaderAdvice {
+        @IsEnabled
+        public static boolean isEnabled() {
+            // good to short-cut advice if no response headers need to be captured
+            return ServletPluginProperties.captureResponseHeadersNonEmpty();
+        }
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindParameter @Nullable String name,
+                @BindParameter @Nullable String value) {
+            if (name == null || value == null) {
+                // seems nothing sensible to do here other than ignore
+                return;
+            }
+            if (!captureResponseHeader(name)) {
+                return;
+            }
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                messageSupplier.addResponseHeader(name, value);
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.http.HttpServletResponse", methodName = "addDateHeader",
+            methodParameterTypes = {"java.lang.String", "long"},
+            nestingGroup = "servlet-inner-call")
+    public static class AddDateHeaderAdvice {
+        @IsEnabled
+        public static boolean isEnabled() {
+            // good to short-cut advice if no response headers need to be captured
+            return ServletPluginProperties.captureResponseHeadersNonEmpty();
+        }
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindParameter @Nullable String name,
+                @BindParameter long value) {
+            if (name == null) {
+                // seems nothing sensible to do here other than ignore
+                return;
+            }
+            if (!captureResponseHeader(name)) {
+                return;
+            }
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                messageSupplier.addResponseDateHeader(name, value);
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.http.HttpServletResponse", methodName = "addIntHeader",
+            methodParameterTypes = {"java.lang.String", "int"}, nestingGroup = "servlet-inner-call")
+    public static class AddIntHeaderAdvice {
+        @IsEnabled
+        public static boolean isEnabled() {
+            // good to short-cut advice if no response headers need to be captured
+            return ServletPluginProperties.captureResponseHeadersNonEmpty();
+        }
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindParameter @Nullable String name,
+                @BindParameter int value) {
+            if (name == null) {
+                // seems nothing sensible to do here other than ignore
+                return;
+            }
+            if (!captureResponseHeader(name)) {
+                return;
+            }
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                messageSupplier.addResponseIntHeader(name, value);
+            }
+        }
+    }
+
+    private static boolean captureResponseHeader(String name) {
+        List<Pattern> capturePatterns = ServletPluginProperties.captureResponseHeaders();
+        // converted to lower case for case-insensitive matching (patterns are lower case)
+        String keyLowerCase = name.toLowerCase(Locale.ENGLISH);
+        return DetailCapture.matchesOneOf(keyLowerCase, capturePatterns);
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/ServletAspect.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/ServletAspect.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright 2011-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet;
+
+import org.glowroot.agent.plugin.api.*;
+import org.glowroot.agent.plugin.api.ThreadContext.Priority;
+import org.glowroot.agent.plugin.api.checker.Nullable;
+import org.glowroot.agent.plugin.api.util.FastThreadLocal;
+import org.glowroot.agent.plugin.api.weaving.*;
+import org.glowroot.agent.plugin.jakartaservlet._.*;
+import org.glowroot.agent.plugin.jakartaservlet._.ServletPluginProperties.SessionAttributePath;
+
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.Map;
+
+// this plugin is careful not to rely on request or session objects being thread-safe
+public class ServletAspect {
+
+    @Pointcut(className = "jakarta.servlet.Servlet", methodName = "service",
+            methodParameterTypes = {"jakarta.servlet.ServletRequest",
+                    "jakarta.servlet.ServletResponse"},
+            nestingGroup = "outer-servlet-or-filter", timerName = "http request")
+    public static class ServiceAdvice {
+        private static final TimerName timerName = Agent.getTimerName(ServiceAdvice.class);
+        @OnBefore
+        public static @Nullable TraceEntry onBefore(OptionalThreadContext context,
+                @BindParameter @Nullable ServletRequest req,
+                @BindClassMeta RequestInvoker requestInvoker) {
+            return onBeforeCommon(context, req, null, requestInvoker);
+        }
+        @OnReturn
+        public static void onReturn(OptionalThreadContext context,
+                @BindTraveler @Nullable TraceEntry traceEntry,
+                @SuppressWarnings("unused") @BindParameter @Nullable ServletRequest req,
+                @BindParameter @Nullable ServletResponse res,
+                @BindClassMeta ResponseInvoker responseInvoker) {
+            if (traceEntry == null) {
+                return;
+            }
+            if (!(res instanceof HttpServletResponse)) {
+                // seems nothing sensible to do here other than ignore
+                return;
+            }
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null && responseInvoker.hasGetStatusMethod()) {
+                messageSupplier.setResponseCode(responseInvoker.getStatus(res));
+            }
+            FastThreadLocal.Holder</*@Nullable*/ String> errorMessageHolder =
+                    SendError.getErrorMessageHolder();
+            String errorMessage = errorMessageHolder.get();
+            if (errorMessage != null) {
+                traceEntry.endWithError(errorMessage);
+                errorMessageHolder.set(null);
+            } else {
+                traceEntry.end();
+            }
+            context.setServletRequestInfo(null);
+        }
+        @OnThrow
+        public static void onThrow(@BindThrowable Throwable t, OptionalThreadContext context,
+                @BindTraveler @Nullable TraceEntry traceEntry,
+                @SuppressWarnings("unused") @BindParameter @Nullable ServletRequest req,
+                @BindParameter @Nullable ServletResponse res) {
+            if (traceEntry == null) {
+                return;
+            }
+            if (res == null || !(res instanceof HttpServletResponse)) {
+                // seems nothing sensible to do here other than ignore
+                return;
+            }
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                // container will set this unless headers are already flushed
+                messageSupplier.setResponseCode(500);
+            }
+            // ignoring potential sendError since this seems worse
+            SendError.clearErrorMessage();
+            traceEntry.endWithError(t);
+            context.setServletRequestInfo(null);
+        }
+        private static @Nullable TraceEntry onBeforeCommon(OptionalThreadContext context,
+                @Nullable ServletRequest req, @Nullable String transactionTypeOverride,
+                RequestInvoker requestInvoker) {
+            if (context.getServletRequestInfo() != null) {
+                return null;
+            }
+            if (!(req instanceof HttpServletRequest)) {
+                // seems nothing sensible to do here other than ignore
+                return null;
+            }
+            HttpServletRequest request = (HttpServletRequest) req;
+            AuxThreadContext auxContextObj = (AuxThreadContext) request
+                    .getAttribute(AsyncServletAspect.GLOWROOT_AUX_CONTEXT_REQUEST_ATTRIBUTE);
+            if (auxContextObj != null) {
+                request.removeAttribute(AsyncServletAspect.GLOWROOT_AUX_CONTEXT_REQUEST_ATTRIBUTE);
+                AuxThreadContext auxContext = auxContextObj;
+                return auxContext.startAndMarkAsyncTransactionComplete();
+            }
+            // request parameter map is collected in GetParameterAdvice
+            // session info is collected here if the request already has a session
+            ServletMessageSupplier messageSupplier;
+            HttpSession session = request.getSession(false);
+            String requestUri = Strings.nullToEmpty(request.getRequestURI());
+            // don't convert null to empty, since null means no query string, while empty means
+            // url ended with ? but nothing after that
+            String requestQueryString = request.getQueryString();
+            String requestMethod = Strings.nullToEmpty(request.getMethod());
+            String requestContextPath = Strings.nullToEmpty(request.getContextPath());
+            String requestServletPath = Strings.nullToEmpty(request.getServletPath());
+            String requestPathInfo = request.getPathInfo();
+            Map<String, Object> requestHeaders = DetailCapture.captureRequestHeaders(request);
+            RequestHostAndPortDetail requestHostAndPortDetail =
+                    DetailCapture.captureRequestHostAndPortDetail(request, requestInvoker);
+            if (session == null) {
+                messageSupplier = new ServletMessageSupplier(requestMethod, requestContextPath,
+                        requestServletPath, requestPathInfo, requestUri, requestQueryString,
+                        requestHeaders, requestHostAndPortDetail,
+                        Collections.<String, String>emptyMap());
+            } else {
+                Map<String, String> sessionAttributes = HttpSessions.getSessionAttributes(session);
+                messageSupplier = new ServletMessageSupplier(requestMethod, requestContextPath,
+                        requestServletPath, requestPathInfo, requestUri, requestQueryString,
+                        requestHeaders, requestHostAndPortDetail, sessionAttributes);
+            }
+            String user = null;
+            if (session != null) {
+                SessionAttributePath userAttributePath =
+                        ServletPluginProperties.userAttributePath();
+                if (userAttributePath != null) {
+                    // capture user now, don't use a lazy supplier
+                    Object val = HttpSessions.getSessionAttribute(session, userAttributePath);
+                    user = val == null ? null : val.toString();
+                }
+            }
+            String transactionType;
+            boolean setWithCoreMaxPriority = false;
+            String transactionTypeHeader = request.getHeader("Glowroot-Transaction-Type");
+            if ("Synthetic".equals(transactionTypeHeader)) {
+                // Glowroot-Transaction-Type header currently only accepts "Synthetic", in order to
+                // prevent spamming of transaction types, which could cause some issues
+                transactionType = transactionTypeHeader;
+                setWithCoreMaxPriority = true;
+            } else if (transactionTypeOverride != null) {
+                transactionType = transactionTypeOverride;
+            } else {
+                transactionType = "Web";
+            }
+            TraceEntry traceEntry = context.startTransaction(transactionType, requestUri,
+                    messageSupplier, timerName);
+            if (setWithCoreMaxPriority) {
+                context.setTransactionType(transactionType, Priority.CORE_MAX);
+            }
+            context.setServletRequestInfo(messageSupplier);
+            // Glowroot-Transaction-Name header is useful for automated tests which want to send a
+            // more specific name for the transaction
+            String transactionNameOverride = request.getHeader("Glowroot-Transaction-Name");
+            if (transactionNameOverride != null) {
+                context.setTransactionName(transactionNameOverride, Priority.CORE_MAX);
+            }
+            if (user != null) {
+                context.setTransactionUser(user, Priority.CORE_PLUGIN);
+            }
+            return traceEntry;
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.Filter", methodName = "doFilter",
+            methodParameterTypes = {"jakarta.servlet.ServletRequest", "jakarta.servlet.ServletResponse",
+                    "jakarta.servlet.FilterChain"},
+            nestingGroup = "outer-servlet-or-filter", timerName = "http request")
+    public static class DoFilterAdvice {
+        @OnBefore
+        public static @Nullable TraceEntry onBefore(OptionalThreadContext context,
+                @BindParameter @Nullable ServletRequest req,
+                @BindClassMeta RequestInvoker requestInvoker) {
+            return ServiceAdvice.onBeforeCommon(context, req, null, requestInvoker);
+        }
+        @OnReturn
+        public static void onReturn(OptionalThreadContext context,
+                @BindTraveler @Nullable TraceEntry traceEntry,
+                @BindParameter @Nullable ServletRequest req,
+                @BindParameter @Nullable ServletResponse res,
+                @BindClassMeta ResponseInvoker responseInvoker) {
+            ServiceAdvice.onReturn(context, traceEntry, req, res, responseInvoker);
+        }
+        @OnThrow
+        public static void onThrow(@BindThrowable Throwable t, OptionalThreadContext context,
+                @BindTraveler @Nullable TraceEntry traceEntry,
+                @BindParameter @Nullable ServletRequest req,
+                @BindParameter @Nullable ServletResponse res) {
+            ServiceAdvice.onThrow(t, context, traceEntry, req, res);
+        }
+    }
+
+    @Pointcut(className = "org.eclipse.jetty.server.Handler"
+            + "|wiremock.org.eclipse.jetty.server.Handler",
+            subTypeRestriction = "/(?!org\\.eclipse\\.jetty.)"
+                    + "(?!wiremock.org\\.eclipse\\.jetty.).*/",
+            methodName = "handle",
+            methodParameterTypes = {"java.lang.String",
+                    "org.eclipse.jetty.server.Request|wiremock.org.eclipse.jetty.server.Request",
+                    "jakarta.servlet.http.HttpServletRequest",
+                    "jakarta.servlet.http.HttpServletResponse"},
+            nestingGroup = "outer-servlet-or-filter", timerName = "http request")
+    public static class JettyHandlerAdvice {
+        @OnBefore
+        public static @Nullable TraceEntry onBefore(OptionalThreadContext context,
+                @SuppressWarnings("unused") @BindParameter @Nullable String target,
+                @SuppressWarnings("unused") @BindParameter @Nullable Object baseRequest,
+                @BindParameter @Nullable ServletRequest req,
+                @BindClassMeta RequestInvoker requestInvoker) {
+            return ServiceAdvice.onBeforeCommon(context, req, null, requestInvoker);
+        }
+        @OnReturn
+        public static void onReturn(OptionalThreadContext context,
+                @BindTraveler @Nullable TraceEntry traceEntry,
+                @SuppressWarnings("unused") @BindParameter @Nullable String target,
+                @SuppressWarnings("unused") @BindParameter @Nullable Object baseRequest,
+                @BindParameter @Nullable ServletRequest req,
+                @BindParameter @Nullable ServletResponse res,
+                @BindClassMeta ResponseInvoker responseInvoker) {
+            ServiceAdvice.onReturn(context, traceEntry, req, res, responseInvoker);
+        }
+        @OnThrow
+        public static void onThrow(@BindThrowable Throwable t, OptionalThreadContext context,
+                @BindTraveler @Nullable TraceEntry traceEntry,
+                @SuppressWarnings("unused") @BindParameter @Nullable String target,
+                @SuppressWarnings("unused") @BindParameter @Nullable Object baseRequest,
+                @BindParameter @Nullable ServletRequest req,
+                @BindParameter @Nullable ServletResponse res) {
+            ServiceAdvice.onThrow(t, context, traceEntry, req, res);
+        }
+    }
+
+    // this pointcut makes sure to only set the transaction type to WireMock if WireMock is the
+    // first servlet encountered
+    @Pointcut(className = "jakarta.servlet.Servlet",
+            subTypeRestriction = "com.github.tomakehurst.wiremock.jetty9"
+                    + ".JettyHandlerDispatchingServlet",
+            methodName = "service",
+            methodParameterTypes = {"jakarta.servlet.ServletRequest",
+                    "jakarta.servlet.ServletResponse"},
+            nestingGroup = "outer-servlet-or-filter", timerName = "http request", order = -1)
+    public static class WireMockAdvice {
+        @OnBefore
+        public static @Nullable TraceEntry onBefore(OptionalThreadContext context,
+                @BindParameter @Nullable ServletRequest req,
+                @BindClassMeta RequestInvoker requestInvoker) {
+            return ServiceAdvice.onBeforeCommon(context, req, "WireMock", requestInvoker);
+        }
+        @OnReturn
+        public static void onReturn(OptionalThreadContext context,
+                @BindTraveler @Nullable TraceEntry traceEntry,
+                @BindParameter @Nullable ServletRequest req,
+                @BindParameter @Nullable ServletResponse res,
+                @BindClassMeta ResponseInvoker responseInvoker) {
+            ServiceAdvice.onReturn(context, traceEntry, req, res, responseInvoker);
+        }
+        @OnThrow
+        public static void onThrow(@BindThrowable Throwable t, OptionalThreadContext context,
+                @BindTraveler @Nullable TraceEntry traceEntry,
+                @BindParameter @Nullable ServletRequest req,
+                @BindParameter @Nullable ServletResponse res) {
+            ServiceAdvice.onThrow(t, context, traceEntry, req, res);
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.http.HttpServletResponse", methodName = "sendError",
+            methodParameterTypes = {"int", ".."}, nestingGroup = "servlet-inner-call")
+    public static class SendErrorAdvice {
+        // wait until after because sendError throws IllegalStateException if the response has
+        // already been committed
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindParameter int statusCode) {
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                messageSupplier.setResponseCode(statusCode);
+            }
+            if (captureAsError(statusCode)) {
+                FastThreadLocal.Holder</*@Nullable*/ String> errorMessageHolder =
+                        SendError.getErrorMessageHolder();
+                if (errorMessageHolder.get() == null) {
+                    context.addErrorEntry("sendError, HTTP status code " + statusCode);
+                    errorMessageHolder.set("sendError, HTTP status code " + statusCode);
+                }
+            }
+        }
+
+        private static boolean captureAsError(int statusCode) {
+            return statusCode >= 500
+                    || ServletPluginProperties.traceErrorOn4xxResponseCode() && statusCode >= 400;
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.http.HttpServletResponse", methodName = "sendRedirect",
+            methodParameterTypes = {"java.lang.String"}, nestingGroup = "servlet-inner-call")
+    public static class SendRedirectAdvice {
+        // wait until after because sendError throws IllegalStateException if the response has
+        // already been committed
+        @OnAfter
+        public static void onAfter(ThreadContext context,
+                @BindReceiver HttpServletResponse response,
+                @BindParameter @Nullable String location,
+                @BindClassMeta ResponseInvoker responseInvoker) {
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                messageSupplier.setResponseCode(302);
+                if (responseInvoker.hasGetHeaderMethod()) {
+                    // get the header as set by the container (e.g. after it converts relative to
+                    // absolute path)
+                    String header = responseInvoker.getHeader(response, "Location");
+                    messageSupplier.addResponseHeader("Location", header);
+                } else if (location != null) {
+                    messageSupplier.addResponseHeader("Location", location);
+                }
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.http.HttpServletResponse", methodName = "setStatus",
+            methodParameterTypes = {"int", ".."}, nestingGroup = "servlet-inner-call")
+    public static class SetStatusAdvice {
+        // wait until after because sendError throws IllegalStateException if the response has
+        // already been committed
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindParameter int statusCode) {
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                messageSupplier.setResponseCode(statusCode);
+            }
+            if (SendErrorAdvice.captureAsError(statusCode)) {
+                FastThreadLocal.Holder</*@Nullable*/ String> errorMessageHolder =
+                        SendError.getErrorMessageHolder();
+                if (errorMessageHolder.get() == null) {
+                    context.addErrorEntry("setStatus, HTTP status code " + statusCode);
+                    errorMessageHolder.set("setStatus, HTTP status code " + statusCode);
+                }
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.http.HttpServletRequest", methodName = "getUserPrincipal",
+            methodParameterTypes = {}, methodReturnType = "java.security.Principal",
+            nestingGroup = "servlet-inner-call")
+    public static class GetUserPrincipalAdvice {
+        @OnReturn
+        public static void onReturn(@BindReturn @Nullable Principal principal,
+                ThreadContext context) {
+            if (principal != null) {
+                context.setTransactionUser(principal.getName(), Priority.CORE_PLUGIN);
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.http.HttpServletRequest", methodName = "getSession",
+            methodParameterTypes = {}, nestingGroup = "servlet-inner-call")
+    public static class GetSessionAdvice {
+        @OnReturn
+        public static void onReturn(@BindReturn @Nullable HttpSession session,
+                ThreadContext context) {
+            if (session == null) {
+                return;
+            }
+            if (ServletPluginProperties.sessionUserAttributeIsId()) {
+                context.setTransactionUser(session.getId(), Priority.CORE_PLUGIN);
+            }
+            if (ServletPluginProperties.captureSessionAttributeNamesContainsId()) {
+                ServletMessageSupplier messageSupplier =
+                        (ServletMessageSupplier) context.getServletRequestInfo();
+                if (messageSupplier != null) {
+                    messageSupplier.putSessionAttributeChangedValue(
+                            ServletPluginProperties.HTTP_SESSION_ID_ATTR, session.getId());
+                }
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.http.HttpServletRequest", methodName = "getSession",
+            methodParameterTypes = {"boolean"}, nestingGroup = "servlet-inner-call")
+    public static class GetSessionOneArgAdvice {
+        @OnReturn
+        public static void onReturn(@BindReturn @Nullable HttpSession session,
+                ThreadContext context) {
+            GetSessionAdvice.onReturn(session, context);
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.Servlet", methodName = "init",
+            methodParameterTypes = {"jakarta.servlet.ServletConfig"})
+    public static class ServiceInitAdvice {
+        @OnBefore
+        public static void onBefore() {
+            ContainerStartup.initPlatformMBeanServer();
+        }
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/SessionAspect.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/SessionAspect.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2011-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet;
+
+import org.glowroot.agent.plugin.api.ThreadContext;
+import org.glowroot.agent.plugin.api.ThreadContext.Priority;
+import org.glowroot.agent.plugin.api.checker.Nullable;
+import org.glowroot.agent.plugin.api.util.Beans;
+import org.glowroot.agent.plugin.api.weaving.BindParameter;
+import org.glowroot.agent.plugin.api.weaving.OnAfter;
+import org.glowroot.agent.plugin.api.weaving.Pointcut;
+import org.glowroot.agent.plugin.jakartaservlet._.ServletMessageSupplier;
+import org.glowroot.agent.plugin.jakartaservlet._.ServletPluginProperties;
+import org.glowroot.agent.plugin.jakartaservlet._.ServletPluginProperties.SessionAttributePath;
+import org.glowroot.agent.plugin.jakartaservlet._.Strings;
+
+import java.util.List;
+import java.util.Map;
+
+public class SessionAspect {
+
+    @Pointcut(className = "jakarta.servlet.http.HttpSession", methodName = "setAttribute|putValue",
+            methodParameterTypes = {"java.lang.String", "java.lang.Object"},
+            nestingGroup = "servlet-inner-call")
+    public static class SetAttributeAdvice {
+
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindParameter @Nullable String name,
+                @BindParameter @Nullable Object value) {
+            if (name == null) {
+                // theoretically possible, so just ignore
+                return;
+            }
+            // name is non-null per HttpSession.setAttribute() javadoc, but value may be null
+            // (which per the javadoc is the same as calling removeAttribute())
+            ServletMessageSupplier messageSupplier =
+                    (ServletMessageSupplier) context.getServletRequestInfo();
+            if (messageSupplier != null) {
+                updateUserIfApplicable(context, name, value);
+                updateSessionAttributesIfApplicable(messageSupplier, name, value);
+            }
+        }
+
+        private static void updateUserIfApplicable(ThreadContext context, String attributeName,
+                @Nullable Object attributeValue) {
+            if (attributeValue == null) {
+                // if user value is set to null, don't clear it
+                return;
+            }
+            SessionAttributePath userAttributePath = ServletPluginProperties.userAttributePath();
+            if (userAttributePath == null) {
+                return;
+            }
+            if (!userAttributePath.getAttributeName().equals(attributeName)) {
+                return;
+            }
+            // capture user now, don't use a lazy supplier
+            List<String> nestedPath = userAttributePath.getNestedPath();
+            if (nestedPath.isEmpty()) {
+                context.setTransactionUser(attributeValue.toString(), Priority.CORE_PLUGIN);
+            } else {
+                Object user;
+                try {
+                    user = Beans.value(attributeValue, nestedPath);
+                } catch (Exception e) {
+                    user = "<could not access: " + e + ">";
+                }
+                if (user != null) {
+                    // if user is null, don't clear it
+                    context.setTransactionUser(user.toString(), Priority.CORE_PLUGIN);
+                }
+            }
+        }
+
+        private static void updateSessionAttributesIfApplicable(
+                ServletMessageSupplier messageSupplier, String attributeName,
+                @Nullable Object attributeValue) {
+            if (ServletPluginProperties.captureSessionAttributeNames().contains(attributeName)
+                    || ServletPluginProperties.captureSessionAttributeNames().contains("*")) {
+                // update all session attributes (possibly nested) at or under the set attribute
+                for (SessionAttributePath attributePath : ServletPluginProperties
+                        .captureSessionAttributePaths()) {
+                    if (attributePath.getAttributeName().equals(attributeName)
+                            || attributePath.isAttributeNameWildcard()) {
+                        if (attributePath.getNestedPath().isEmpty()
+                                && !attributePath.isWildcard()) {
+                            updateSessionAttribute(messageSupplier, attributeName, attributeValue);
+                        } else {
+                            updateNestedSessionAttributes(messageSupplier, attributePath,
+                                    attributeValue);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void updateSessionAttribute(ServletMessageSupplier messageSupplier,
+                String attributeName, @Nullable Object attributeValue) {
+            if (attributeValue == null) {
+                messageSupplier.putSessionAttributeChangedValue(attributeName, null);
+            } else {
+                messageSupplier.putSessionAttributeChangedValue(attributeName,
+                        Strings.nullToEmpty(attributeValue.toString()));
+            }
+        }
+
+        private static void updateNestedSessionAttributes(ServletMessageSupplier messageSupplier,
+                SessionAttributePath attributePath, @Nullable Object attributeValue) {
+            String fullPath = attributePath.getFullPath();
+            if (attributePath.isWildcard()) {
+                Object val = HttpSessions.getSessionAttribute(attributeValue, attributePath);
+                if (val == null) {
+                    messageSupplier.putSessionAttributeChangedValue(fullPath, null);
+                } else if (val instanceof Map<?, ?>) {
+                    for (Map.Entry<?, ?> entry : ((Map<?, ?>) val).entrySet()) {
+                        Object v = entry.getValue();
+                        messageSupplier.putSessionAttributeChangedValue(
+                                fullPath + "." + entry.getKey(),
+                                v == null ? null : Strings.nullToEmpty(v.toString()));
+                    }
+                } else {
+                    for (Map.Entry<String, String> entry : Beans.propertiesAsText(val).entrySet()) {
+                        messageSupplier.putSessionAttributeChangedValue(
+                                fullPath + "." + entry.getKey(), entry.getValue());
+                    }
+                }
+            } else if (attributeValue == null) {
+                // no need to navigate path since it will always be null
+                messageSupplier.putSessionAttributeChangedValue(fullPath, null);
+            } else {
+                Object val = HttpSessions.getSessionAttribute(attributeValue, attributePath);
+                messageSupplier.putSessionAttributeChangedValue(fullPath,
+                        val == null ? null : Strings.nullToEmpty(val.toString()));
+            }
+        }
+    }
+
+    @Pointcut(className = "jakarta.servlet.http.HttpSession", methodName = "removeAttribute",
+            methodParameterTypes = {"java.lang.String"}, nestingGroup = "servlet-inner-call")
+    public static class RemoveAttributeAdvice {
+        @OnAfter
+        public static void onAfter(ThreadContext context, @BindParameter @Nullable String name) {
+            // calling HttpSession.setAttribute() with null value is the same as calling
+            // removeAttribute(), per the setAttribute() javadoc
+            SetAttributeAdvice.onAfter(context, name, null);
+        }
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/RequestClassMeta.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/RequestClassMeta.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet._;
+
+import org.glowroot.agent.plugin.api.ClassInfo;
+
+public class RequestClassMeta {
+
+    private boolean badParameterMapImplementation;
+
+    public RequestClassMeta(@SuppressWarnings("unused") ClassInfo classInfo) {}
+
+    public boolean isBadParameterMapImplementation() {
+        return badParameterMapImplementation;
+    }
+
+    public void setBadParameterMapImplementation() {
+        this.badParameterMapImplementation = true;
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/RequestHostAndPortDetail.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/RequestHostAndPortDetail.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet._;
+
+import org.glowroot.agent.plugin.api.checker.Nullable;
+
+public class RequestHostAndPortDetail {
+
+    // -1 is used as error return value by RequestInvoker.getRemotePort()
+    public static final int UNSET = -2;
+    public @Nullable String remoteAddress;
+    public @Nullable String remoteHostname;
+    public int remotePort = UNSET;
+    public @Nullable String localAddress;
+    public @Nullable String localHostname;
+    public int localPort = UNSET;
+    public @Nullable String serverHostname;
+    public int serverPort = UNSET;
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/RequestInvoker.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/RequestInvoker.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet._;
+
+import org.glowroot.agent.plugin.api.ClassInfo;
+import org.glowroot.agent.plugin.api.checker.Nullable;
+import org.glowroot.agent.plugin.api.util.Reflection;
+
+import java.lang.reflect.Method;
+
+public class RequestInvoker {
+
+    // these ServletRequest methods were introduced in Servlet 3.0
+    private final @Nullable Method getRemotePortMethod;
+    private final @Nullable Method getLocalAddrMethod;
+    private final @Nullable Method getLocalNameMethod;
+    private final @Nullable Method getLocalPortMethod;
+
+    public RequestInvoker(ClassInfo classInfo) {
+        Class<?> servletRequestClass = Reflection
+                .getClassWithWarnIfNotFound("jakarta.servlet.ServletRequest", classInfo.getLoader());
+        getRemotePortMethod = Reflection.getMethod(servletRequestClass, "getRemotePort");
+        getLocalAddrMethod = Reflection.getMethod(servletRequestClass, "getLocalAddr");
+        getLocalNameMethod = Reflection.getMethod(servletRequestClass, "getLocalName");
+        getLocalPortMethod = Reflection.getMethod(servletRequestClass, "getLocalPort");
+    }
+
+    public int getRemotePort(Object request) {
+        return Reflection.invokeWithDefault(getRemotePortMethod, request, -1);
+    }
+
+    public String getLocalAddr(Object request) {
+        return Reflection.invokeWithDefault(getLocalAddrMethod, request, "");
+    }
+
+    public String getLocalName(Object request) {
+        return Reflection.invokeWithDefault(getLocalNameMethod, request, "");
+    }
+
+    public int getLocalPort(Object request) {
+        return Reflection.invokeWithDefault(getLocalPortMethod, request, -1);
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/ResponseHeaderComponent.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/ResponseHeaderComponent.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet._;
+
+import org.glowroot.agent.plugin.api.Logger;
+import org.glowroot.agent.plugin.api.checker.MonotonicNonNull;
+import org.glowroot.agent.plugin.api.checker.Nullable;
+
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+// this class is thread safe since it is part of the thread safe ServletMessageSupplier (see comment
+// in ServletMessageSupplier for details why)
+class ResponseHeaderComponent {
+
+    private static final Logger logger = Logger.getLogger(ServletMessageSupplier.class);
+
+    // HTTP response header date format (RFC 1123)
+    // also see org.apache.tomcat.util.http.FastHttpDateFormat
+    private static final SimpleDateFormat responseHeaderDateFormat =
+            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
+
+    static {
+        // all HTTP dates are on GMT
+        responseHeaderDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+    }
+
+    // map key is uppercase for case-insensitivity
+    private @MonotonicNonNull ConcurrentMap<String, ResponseHeader> responseHeaders;
+
+    synchronized Map<String, Object> getMapOfStrings() {
+        if (responseHeaders == null) {
+            return Collections.emptyMap();
+        }
+        // lazy format int and date headers as strings since this method is only called if
+        // it is really needed (for storage or display of active trace)
+        Map<String, Object> responseHeaderStrings = new HashMap<String, Object>();
+        for (ResponseHeader responseHeader : responseHeaders.values()) {
+            String name = responseHeader.getName();
+            List<Object> values = responseHeader.getValues();
+            if (values != null) {
+                List<String> headerValueStrings = new ArrayList<String>();
+                for (Object v : values) {
+                    headerValueStrings.add(headerValueString(v));
+                }
+                responseHeaderStrings.put(name, headerValueStrings);
+            } else {
+                Object value = responseHeader.getValue();
+                responseHeaderStrings.put(name, headerValueString(value));
+            }
+        }
+        return responseHeaderStrings;
+    }
+
+    synchronized void setHeader(String name, Object value) {
+        if (responseHeaders == null) {
+            responseHeaders = new ConcurrentHashMap<String, ResponseHeader>();
+        }
+        String nameUpper = name.toUpperCase(Locale.ENGLISH);
+        ResponseHeader responseHeader = responseHeaders.get(nameUpper);
+        if (responseHeader == null) {
+            responseHeaders.put(nameUpper, new ResponseHeader(name, value));
+        } else {
+            responseHeader.setValue(value);
+        }
+    }
+
+    synchronized void addHeader(String name, Object value) {
+        if (responseHeaders == null) {
+            responseHeaders = new ConcurrentHashMap<String, ResponseHeader>();
+        }
+        String nameUpper = name.toUpperCase(Locale.ENGLISH);
+        ResponseHeader responseHeader = responseHeaders.get(nameUpper);
+        if (responseHeader == null) {
+            responseHeaders.put(nameUpper, new ResponseHeader(name, value));
+        } else {
+            responseHeader.addValue(value);
+        }
+    }
+
+    private static String headerValueString(Object value) {
+        if (value instanceof String) {
+            return (String) value;
+        } else if (value instanceof Integer) {
+            return Integer.toString((Integer) value);
+        } else if (value instanceof Long) {
+            // this is only called on traces that need to be stored (or an active trace being viewed
+            // inflight in the UI), so date format overhead seems acceptable
+            synchronized (responseHeaderDateFormat) {
+                return responseHeaderDateFormat.format(new Date((Long) value));
+            }
+        } else {
+            logger.warn("unexpected value type found: {}", value);
+            return "<unexpected value type: " + value.getClass() + ">";
+        }
+    }
+
+    // this class is thread safe since it is part of the thread safe ServletMessageSupplier (see
+    // comment in ServletMessageSupplier for details why)
+    private static class ResponseHeader {
+
+        private final String name;
+        private volatile Object value;
+        private volatile @MonotonicNonNull CopyOnWriteArrayList<Object> values;
+
+        private ResponseHeader(String name, Object value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        private String getName() {
+            return name;
+        }
+
+        private Object getValue() {
+            return value;
+        }
+
+        private @Nullable List<Object> getValues() {
+            return values;
+        }
+
+        private void setValue(Object value) {
+            this.value = value;
+        }
+
+        private void addValue(Object newValue) {
+            if (values == null) {
+                values = new CopyOnWriteArrayList<Object>();
+                values.add(value);
+            }
+            values.add(newValue);
+        }
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/ResponseInvoker.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/ResponseInvoker.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet._;
+
+import org.glowroot.agent.plugin.api.ClassInfo;
+import org.glowroot.agent.plugin.api.checker.Nullable;
+import org.glowroot.agent.plugin.api.util.Reflection;
+
+import java.lang.reflect.Method;
+
+public class ResponseInvoker {
+
+    // ServletResponse.getContentType() was introduced in Servlet 2.4
+    private final @Nullable Method getContentTypeMethod;
+    // HttpServletResponse.getHeader() was introduced in Servlet 3.0
+    private final @Nullable Method getHeaderMethod;
+    // HttpServletResponse.getStatus() was introduced in Servlet 3.0
+    private final @Nullable Method getStatusMethod;
+
+    public ResponseInvoker(ClassInfo classInfo) {
+        Class<?> servletResponseClass = Reflection
+                .getClassWithWarnIfNotFound("jakarta.servlet.ServletResponse", classInfo.getLoader());
+        getContentTypeMethod = Reflection.getMethod(servletResponseClass, "getContentType");
+        Class<?> httpServletResponseClass = Reflection.getClassWithWarnIfNotFound(
+                "jakarta.servlet.http.HttpServletResponse", classInfo.getLoader());
+        getHeaderMethod = Reflection.getMethod(httpServletResponseClass, "getHeader", String.class);
+        getStatusMethod = Reflection.getMethod(httpServletResponseClass, "getStatus");
+    }
+
+    public boolean hasGetContentTypeMethod() {
+        return getContentTypeMethod != null;
+    }
+
+    public String getContentType(Object response) {
+        return Reflection.invokeWithDefault(getContentTypeMethod, response, "");
+    }
+
+    public boolean hasGetHeaderMethod() {
+        return getHeaderMethod != null;
+    }
+
+    public String getHeader(Object response, String name) {
+        return Reflection.invokeWithDefault(getHeaderMethod, response, "", name);
+    }
+
+    public boolean hasGetStatusMethod() {
+        return getStatusMethod != null;
+    }
+
+    public int getStatus(Object response) {
+        return Reflection.invokeWithDefault(getStatusMethod, response, -1);
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/SendError.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/SendError.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet._;
+
+import org.glowroot.agent.plugin.api.util.FastThreadLocal;
+import org.glowroot.agent.plugin.api.util.FastThreadLocal.Holder;
+
+public class SendError {
+
+    private static final FastThreadLocal</*@Nullable*/ String> fastThreadLocal =
+            new FastThreadLocal</*@Nullable*/ String>();
+
+    public static Holder</*@Nullable*/ String> getErrorMessageHolder() {
+        return fastThreadLocal.getHolder();
+    }
+
+    public static void clearErrorMessage() {
+        fastThreadLocal.set(null);
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/ServletMessageSupplier.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/ServletMessageSupplier.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2011-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet._;
+
+import org.glowroot.agent.plugin.api.Message;
+import org.glowroot.agent.plugin.api.MessageSupplier;
+import org.glowroot.agent.plugin.api.ThreadContext.ServletRequestInfo;
+import org.glowroot.agent.plugin.api.checker.MonotonicNonNull;
+import org.glowroot.agent.plugin.api.checker.Nullable;
+import org.glowroot.agent.plugin.api.checker.RequiresNonNull;
+import org.glowroot.agent.plugin.api.util.Optional;
+import org.glowroot.agent.plugin.jakartaservlet.DetailCapture;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.regex.Pattern;
+
+// this class is thread-safe (unlike other MessageSuppliers) since it gets passed around to
+// auxiliary thread contexts for handling async servlets
+public class ServletMessageSupplier extends MessageSupplier implements ServletRequestInfo {
+
+    private static final String MASK_TEXT = "****";
+
+    private final String requestMethod;
+    private final String requestContextPath;
+    private final String requestServletPath;
+    private final @Nullable String requestPathInfo;
+    private final String requestUri;
+    private final @Nullable String requestQueryString;
+
+    private volatile @MonotonicNonNull Map<String, Object> requestParameters;
+
+    private final Map<String, Object> requestHeaders;
+
+    private final @Nullable RequestHostAndPortDetail requestHostAndPortDetail;
+
+    private volatile int responseCode;
+
+    private final ResponseHeaderComponent responseHeaderComponent = new ResponseHeaderComponent();
+
+    // session attributes may not be thread safe, so they must be converted to Strings
+    // within the request processing thread, which can then be safely read by the trace storage
+    // thread (and live viewing thread also)
+    // the initial value map contains the session attributes as they were present at the beginning
+    // of the request
+    private final Map<String, String> sessionAttributeInitialValueMap;
+
+    // ConcurrentHashMap does not allow null values, so need to use Optional values
+    private volatile @MonotonicNonNull ConcurrentMap<String, Optional<String>> sessionAttributeUpdatedValueMap;
+
+    private @Nullable List<String> jaxRsParts;
+
+    public ServletMessageSupplier(String requestMethod, String requestContextPath,
+                                  String requestServletPath, @Nullable String requestPathInfo, String requestUri,
+                                  @Nullable String requestQueryString, Map<String, Object> requestHeaders,
+                                  @Nullable RequestHostAndPortDetail requestHostAndPortDetail,
+                                  Map<String, String> sessionAttributeMap) {
+        this.requestMethod = requestMethod;
+        this.requestContextPath = requestContextPath;
+        this.requestServletPath = requestServletPath;
+        this.requestPathInfo = requestPathInfo;
+        this.requestUri = requestUri;
+        this.requestQueryString = requestQueryString;
+        this.requestHeaders = requestHeaders;
+        this.requestHostAndPortDetail = requestHostAndPortDetail;
+        this.sessionAttributeInitialValueMap = sessionAttributeMap;
+    }
+
+    @Override
+    public Message get() {
+        List<Pattern> maskPatterns = ServletPluginProperties.maskRequestParameters();
+        Map<String, Object> detail = new LinkedHashMap<String, Object>();
+        detail.put("Request http method", requestMethod);
+        String maskedRequestQueryString = maskRequestQueryString(requestQueryString, maskPatterns);
+        if (maskedRequestQueryString != null) {
+            // including empty query string since that means request ended with ?
+            detail.put("Request query string", maskedRequestQueryString);
+        }
+        Map<String, Object> maskedRequestParameters =
+                maskRequestParameters(requestParameters, maskPatterns);
+        if (maskedRequestParameters != null && !maskedRequestParameters.isEmpty()) {
+            detail.put("Request parameters", maskedRequestParameters);
+        }
+        if (!requestHeaders.isEmpty()) {
+            detail.put("Request headers", requestHeaders);
+        }
+        if (requestHostAndPortDetail != null) {
+            if (requestHostAndPortDetail.remoteAddress != null) {
+                detail.put("Request remote address", requestHostAndPortDetail.remoteAddress);
+            }
+            if (requestHostAndPortDetail.remoteHostname != null) {
+                detail.put("Request remote hostname", requestHostAndPortDetail.remoteHostname);
+            }
+            if (requestHostAndPortDetail.remotePort != RequestHostAndPortDetail.UNSET) {
+                detail.put("Request remote port", requestHostAndPortDetail.remotePort);
+            }
+            if (requestHostAndPortDetail.localAddress != null) {
+                detail.put("Request local address", requestHostAndPortDetail.localAddress);
+            }
+            if (requestHostAndPortDetail.localHostname != null) {
+                detail.put("Request local hostname", requestHostAndPortDetail.localHostname);
+            }
+            if (requestHostAndPortDetail.localPort != RequestHostAndPortDetail.UNSET) {
+                detail.put("Request local port", requestHostAndPortDetail.localPort);
+            }
+            if (requestHostAndPortDetail.serverHostname != null) {
+                detail.put("Request server hostname", requestHostAndPortDetail.serverHostname);
+            }
+            if (requestHostAndPortDetail.serverPort != RequestHostAndPortDetail.UNSET) {
+                detail.put("Request server port", requestHostAndPortDetail.serverPort);
+            }
+        }
+        if (responseCode != 0) {
+            detail.put("Response code", responseCode);
+        }
+        Map<String, Object> responseHeaderStrings = responseHeaderComponent.getMapOfStrings();
+        if (!responseHeaderStrings.isEmpty()) {
+            detail.put("Response headers", responseHeaderStrings);
+        }
+        addSessionAttributeDetail(detail);
+        return Message.create(requestUri, detail);
+    }
+
+    @Override
+    public String getMethod() {
+        return requestMethod;
+    }
+
+    @Override
+    public String getContextPath() {
+        return requestContextPath;
+    }
+
+    @Override
+    public String getServletPath() {
+        return requestServletPath;
+    }
+
+    @Override
+    public @Nullable String getPathInfo() {
+        return requestPathInfo;
+    }
+
+    @Override
+    public String getUri() {
+        return requestUri;
+    }
+
+    @Override
+    public void addJaxRsPart(String part) {
+        if (jaxRsParts == null) {
+            jaxRsParts = new ArrayList<String>();
+        }
+        jaxRsParts.add(part);
+    }
+
+    @Override
+    public List<String> getJaxRsParts() {
+        return jaxRsParts == null ? Collections.<String>emptyList() : jaxRsParts;
+    }
+
+    public boolean isRequestParametersCaptured() {
+        return requestParameters != null;
+    }
+
+    public void setCaptureRequestParameters(Map<String, Object> requestParameters) {
+        this.requestParameters = requestParameters;
+    }
+
+    public void setResponseCode(int responseCode) {
+        this.responseCode = responseCode;
+    }
+
+    public void setResponseHeader(String name, String value) {
+        responseHeaderComponent.setHeader(name, value);
+    }
+
+    public void setResponseDateHeader(String name, long date) {
+        responseHeaderComponent.setHeader(name, date);
+    }
+
+    public void setResponseIntHeader(String name, int value) {
+        responseHeaderComponent.setHeader(name, value);
+    }
+
+    public void setResponseLongHeader(String name, long value) {
+        responseHeaderComponent.setHeader(name, value);
+    }
+
+    public void addResponseHeader(String name, String value) {
+        responseHeaderComponent.addHeader(name, value);
+    }
+
+    public void addResponseDateHeader(String name, long date) {
+        responseHeaderComponent.addHeader(name, date);
+    }
+
+    public void addResponseIntHeader(String name, int value) {
+        responseHeaderComponent.addHeader(name, value);
+    }
+
+    public void putSessionAttributeChangedValue(String attributeName,
+            @Nullable String attributeValue) {
+        if (sessionAttributeUpdatedValueMap == null) {
+            sessionAttributeUpdatedValueMap = new ConcurrentHashMap<String, Optional<String>>();
+        }
+        sessionAttributeUpdatedValueMap.put(attributeName, Optional.fromNullable(attributeValue));
+    }
+
+    private void addSessionAttributeDetail(Map<String, Object> detail) {
+        if (!sessionAttributeInitialValueMap.isEmpty()) {
+            if (sessionAttributeUpdatedValueMap == null) {
+                // session attributes were captured at the beginning of the request, and no session
+                // attributes were updated mid-request
+                detail.put("Session attributes", sessionAttributeInitialValueMap);
+            } else {
+                // some session attributes were updated mid-request
+                addMidRequestSessionAttributeDetail(detail);
+            }
+        } else if (sessionAttributeUpdatedValueMap != null) {
+            // no session attributes were available at the beginning of the request, and session
+            // attributes were updated mid-request
+            detail.put("Session attributes (updated during this request)",
+                    sessionAttributeUpdatedValueMap);
+        } else {
+            // both initial and updated value maps are null so there is nothing to add to the
+            // detail map
+        }
+    }
+
+    @RequiresNonNull("sessionAttributeUpdatedValueMap")
+    private void addMidRequestSessionAttributeDetail(Map<String, Object> detail) {
+        Map<String, /*@Nullable*/ Object> sessionAttributeInitialValuePlusMap =
+                new HashMap<String, /*@Nullable*/ Object>();
+        sessionAttributeInitialValuePlusMap.putAll(sessionAttributeInitialValueMap);
+        // add empty values into initial values for any updated attributes that are not
+        // already present in initial values nested detail map
+        for (Map.Entry<String, Optional<String>> entry : sessionAttributeUpdatedValueMap
+                .entrySet()) {
+            if (!sessionAttributeInitialValueMap.containsKey(entry.getKey())) {
+                sessionAttributeInitialValuePlusMap.put(entry.getKey(), null);
+            }
+        }
+        detail.put("Session attributes (at beginning of this request)",
+                sessionAttributeInitialValuePlusMap);
+        detail.put("Session attributes (updated during this request)",
+                sessionAttributeUpdatedValueMap);
+    }
+
+    static @Nullable String maskRequestQueryString(@Nullable String requestQueryString,
+            List<Pattern> maskPatterns) {
+        if (requestQueryString == null) {
+            return null;
+        }
+        if (maskPatterns.isEmpty()) {
+            return requestQueryString;
+        }
+        StringBuilder sb = new StringBuilder(requestQueryString.length());
+        boolean existMaskedParameters = false;
+        int keyStartIndex = 0;
+        boolean inMaskedValue = false;
+        for (int i = 0; i < requestQueryString.length(); i++) {
+            char c = requestQueryString.charAt(i);
+            switch (c) {
+                case '&':
+                    sb.append('&');
+                    keyStartIndex = sb.length();
+                    inMaskedValue = false;
+                    break;
+                case '=':
+                    if (keyStartIndex == -1) {
+                        // not in key
+                        if (!inMaskedValue) {
+                            sb.append(c);
+                        }
+                    } else {
+                        String key = sb.substring(keyStartIndex, sb.length());
+                        sb.append('=');
+                        // converted to lower case for case-insensitive matching
+                        // (patterns are lower case)
+                        String keyLowerCase = key.toLowerCase(Locale.ENGLISH);
+                        if (DetailCapture.matchesOneOf(keyLowerCase, maskPatterns)) {
+                            inMaskedValue = true;
+                            sb.append(MASK_TEXT);
+                            existMaskedParameters = true;
+                        }
+                        keyStartIndex = -1;
+                    }
+                    break;
+                default:
+                    if (!inMaskedValue) {
+                        sb.append(c);
+                    }
+            }
+        }
+        if (existMaskedParameters) {
+            return sb.toString();
+        } else {
+            // save the expense of toString() in common case
+            return requestQueryString;
+        }
+    }
+
+    private static @Nullable Map<String, Object> maskRequestParameters(
+            @Nullable Map<String, Object> requestParameters, List<Pattern> maskPatterns) {
+        if (requestParameters == null) {
+            return null;
+        }
+        if (maskPatterns.isEmpty()) {
+            return requestParameters;
+        }
+        Map<String, Object> maskedRequestParameters = new LinkedHashMap<String, Object>();
+        for (Map.Entry<String, Object> entry : requestParameters.entrySet()) {
+            String name = entry.getKey();
+            // converted to lower case for case-insensitive matching (patterns are lower case)
+            String keyLowerCase = name.toLowerCase(Locale.ENGLISH);
+            if (DetailCapture.matchesOneOf(keyLowerCase, maskPatterns)) {
+                maskedRequestParameters.put(name, MASK_TEXT);
+            } else {
+                maskedRequestParameters.put(name, entry.getValue());
+            }
+        }
+        return maskedRequestParameters;
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/ServletPluginProperties.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/ServletPluginProperties.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2011-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet._;
+
+import org.glowroot.agent.plugin.api.Agent;
+import org.glowroot.agent.plugin.api.checker.Nullable;
+import org.glowroot.agent.plugin.api.config.ConfigListener;
+import org.glowroot.agent.plugin.api.config.ConfigService;
+import org.glowroot.agent.plugin.api.util.ImmutableList;
+import org.glowroot.agent.plugin.api.util.ImmutableSet;
+import org.glowroot.agent.plugin.jakartaservlet.DetailCapture;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class ServletPluginProperties {
+
+    public static final String HTTP_SESSION_ID_ATTR = "::id";
+
+    private static final ConfigService configService = Agent.getConfigService("jakartaservlet");
+
+    private static List<Pattern> captureRequestParameters = Collections.emptyList();
+    private static List<Pattern> maskRequestParameters = Collections.emptyList();
+    private static List<Pattern> captureRequestHeaders = Collections.emptyList();
+
+    private static boolean someRequestHostAndPortDetail;
+    private static boolean captureRequestRemoteAddress;
+    private static boolean captureRequestRemoteHostname;
+    private static boolean captureRequestRemotePort;
+    private static boolean captureRequestLocalAddress;
+    private static boolean captureRequestLocalHostname;
+    private static boolean captureRequestLocalPort;
+    private static boolean captureRequestServerHostname;
+    private static boolean captureRequestServerPort;
+
+    private static List<Pattern> captureResponseHeaders = Collections.emptyList();
+    private static boolean captureResponseHeadersNonEmpty;
+    private static boolean captureContentLengthResponseHeader;
+    private static boolean captureContentTypeResponseHeader;
+    private static boolean captureContentLanguageResponseHeader;
+
+    private static @Nullable SessionAttributePath userAttributePath;
+
+    private static List<SessionAttributePath> captureSessionAttributePaths =
+            Collections.emptyList();
+    private static Set<String> captureSessionAttributeNames = Collections.emptySet();
+    private static boolean captureSessionAttributeNamesContainsId;
+
+    private static boolean traceErrorOn4xxResponseCode;
+
+    static {
+        configService.registerConfigListener(new ServletPluginConfigListener());
+    }
+
+    private ServletPluginProperties() {}
+
+    public static List<Pattern> captureRequestParameters() {
+        return captureRequestParameters;
+    }
+
+    public static List<Pattern> maskRequestParameters() {
+        return maskRequestParameters;
+    }
+
+    public static List<Pattern> captureRequestHeaders() {
+        return captureRequestHeaders;
+    }
+
+    public static boolean captureSomeRequestHostAndPortDetail() {
+        return someRequestHostAndPortDetail;
+    }
+
+    public static boolean captureRequestRemoteAddress() {
+        return captureRequestRemoteAddress;
+    }
+
+    public static boolean captureRequestRemoteHostname() {
+        return captureRequestRemoteHostname;
+    }
+
+    public static boolean captureRequestRemotePort() {
+        return captureRequestRemotePort;
+    }
+
+    public static boolean captureRequestLocalAddress() {
+        return captureRequestLocalAddress;
+    }
+
+    public static boolean captureRequestLocalHostname() {
+        return captureRequestLocalHostname;
+    }
+
+    public static boolean captureRequestLocalPort() {
+        return captureRequestLocalPort;
+    }
+
+    public static boolean captureRequestServerHostname() {
+        return captureRequestServerHostname;
+    }
+
+    public static boolean captureRequestServerPort() {
+        return captureRequestServerPort;
+    }
+
+    public static List<Pattern> captureResponseHeaders() {
+        return captureResponseHeaders;
+    }
+
+    public static boolean captureResponseHeadersNonEmpty() {
+        return captureResponseHeadersNonEmpty;
+    }
+
+    public static boolean captureContentLengthResponseHeader() {
+        return captureContentLengthResponseHeader;
+    }
+
+    public static boolean captureContentTypeResponseHeader() {
+        return captureContentTypeResponseHeader;
+    }
+
+    public static boolean captureContentLanguageResponseHeader() {
+        return captureContentLanguageResponseHeader;
+    }
+
+    public static @Nullable SessionAttributePath userAttributePath() {
+        return userAttributePath;
+    }
+
+    public static boolean sessionUserAttributeIsId() {
+        return userAttributePath != null && userAttributePath.isSessionId();
+    }
+
+    public static List<SessionAttributePath> captureSessionAttributePaths() {
+        return captureSessionAttributePaths;
+    }
+
+    // only the first-level attribute names (e.g. "one", "abc") as opposed to full paths (e.g.
+    // "one.two", "abc.def") returned by captureSessionAttributePaths()
+    public static Set<String> captureSessionAttributeNames() {
+        return captureSessionAttributeNames;
+    }
+
+    public static boolean captureSessionAttributeNamesContainsId() {
+        return captureSessionAttributeNamesContainsId;
+    }
+
+    public static boolean traceErrorOn4xxResponseCode() {
+        return traceErrorOn4xxResponseCode;
+    }
+
+    public static class SessionAttributePath {
+
+        private final String attributeName;
+        private final List<String> nestedPath;
+        private final boolean wildcard;
+
+        private final String fullPath; // attributeName + nestedPath, cached for optimization
+
+        private SessionAttributePath(String attributeName, List<String> nestedPath,
+                boolean wildcard, String fullPath) {
+            this.attributeName = attributeName;
+            this.nestedPath = nestedPath;
+            this.wildcard = wildcard;
+            this.fullPath = fullPath;
+        }
+
+        public String getAttributeName() {
+            return attributeName;
+        }
+
+        public List<String> getNestedPath() {
+            return nestedPath;
+        }
+
+        public boolean isWildcard() {
+            return wildcard;
+        }
+
+        public String getFullPath() {
+            return fullPath;
+        }
+
+        public boolean isAttributeNameWildcard() {
+            return attributeName.equals("*") && nestedPath.isEmpty() && !wildcard;
+        }
+
+        public boolean isSessionId() {
+            return attributeName.equals(ServletPluginProperties.HTTP_SESSION_ID_ATTR)
+                    && nestedPath.isEmpty() && !wildcard;
+        }
+    }
+
+    private static class ServletPluginConfigListener implements ConfigListener {
+
+        @Override
+        public void onChange() {
+            recalculateProperties();
+        }
+
+        private static void recalculateProperties() {
+            captureRequestParameters = buildPatternList("captureRequestParameters");
+            maskRequestParameters = buildPatternList("maskRequestParameters");
+            captureRequestHeaders = buildPatternList("captureRequestHeaders");
+            captureRequestRemoteAddress =
+                    configService.getBooleanProperty("captureRequestRemoteAddr").value();
+            captureRequestRemoteHostname =
+                    configService.getBooleanProperty("captureRequestRemoteHostname").value();
+            captureRequestRemotePort =
+                    configService.getBooleanProperty("captureRequestRemotePort").value();
+            captureRequestLocalAddress =
+                    configService.getBooleanProperty("captureRequestLocalAddr").value();
+            captureRequestLocalHostname =
+                    configService.getBooleanProperty("captureRequestLocalHostname").value();
+            captureRequestLocalPort =
+                    configService.getBooleanProperty("captureRequestLocalPort").value();
+            captureRequestServerHostname =
+                    configService.getBooleanProperty("captureRequestServerHostname").value();
+            captureRequestServerPort =
+                    configService.getBooleanProperty("captureRequestServerPort").value();
+            someRequestHostAndPortDetail =
+                    captureRequestRemoteAddress || captureRequestRemoteHostname
+                            || captureRequestRemotePort || captureRequestLocalAddress
+                            || captureRequestLocalHostname || captureRequestLocalPort
+                            || captureRequestServerHostname || captureRequestServerPort;
+            captureResponseHeaders = buildPatternList("captureResponseHeaders");
+            captureResponseHeadersNonEmpty = !captureResponseHeaders.isEmpty();
+            captureContentLengthResponseHeader =
+                    DetailCapture.matchesOneOf("content-length", captureResponseHeaders);
+            captureContentTypeResponseHeader =
+                    DetailCapture.matchesOneOf("content-type", captureResponseHeaders);
+            captureContentLanguageResponseHeader =
+                    DetailCapture.matchesOneOf("content-language", captureResponseHeaders);
+            userAttributePath = buildSessionAttributePath(
+                    configService.getStringProperty("sessionUserAttribute").value());
+            captureSessionAttributePaths = buildSessionAttributePaths(
+                    configService.getListProperty("captureSessionAttributes").value());
+            captureSessionAttributeNames = buildCaptureSessionAttributeNames();
+            captureSessionAttributeNamesContainsId =
+                    captureSessionAttributeNames.contains(HTTP_SESSION_ID_ATTR);
+            traceErrorOn4xxResponseCode =
+                    configService.getBooleanProperty("traceErrorOn4xxResponseCode").value();
+        }
+
+        private static List<Pattern> buildPatternList(String propertyName) {
+            List<String> values = configService.getListProperty(propertyName).value();
+            List<Pattern> patterns = new ArrayList<Pattern>();
+            for (String value : values) {
+                // converted to lower case for case-insensitive matching
+                patterns.add(buildRegexPattern(value.trim().toLowerCase(Locale.ENGLISH)));
+            }
+            return ImmutableList.copyOf(patterns);
+        }
+
+        private static List<SessionAttributePath> buildSessionAttributePaths(
+                List<String> sessionAttributes) {
+            List<SessionAttributePath> attributePaths = new ArrayList<SessionAttributePath>();
+            for (String sessionAttribute : sessionAttributes) {
+                attributePaths.add(buildSessionAttributePath(sessionAttribute.trim()));
+            }
+            return ImmutableList.copyOf(attributePaths);
+        }
+
+        private static SessionAttributePath buildSessionAttributePath(String sessionAttribute) {
+            boolean wildcard = sessionAttribute.endsWith(".*");
+            String sessionAttr = sessionAttribute;
+            if (wildcard) {
+                sessionAttr = sessionAttribute.substring(0, sessionAttribute.length() - 2);
+            }
+            int index = sessionAttr.indexOf('.');
+            if (index == -1) {
+                return new SessionAttributePath(sessionAttr, Collections.<String>emptyList(),
+                        wildcard, sessionAttr);
+            } else {
+                String attributeName = sessionAttr.substring(0, index);
+                String remaining = sessionAttr.substring(index + 1);
+                List<String> nestedPath = Strings.split(remaining, '.');
+                return new SessionAttributePath(attributeName, nestedPath, wildcard, sessionAttr);
+            }
+        }
+
+        private static Set<String> buildCaptureSessionAttributeNames() {
+            Set<String> names = new HashSet<String>();
+            for (SessionAttributePath sessionAttributePath : captureSessionAttributePaths) {
+                names.add(sessionAttributePath.attributeName);
+            }
+            return ImmutableSet.copyOf(names);
+        }
+
+        private static Pattern buildRegexPattern(String wildcardPattern) {
+            // convert * into .* and quote the rest of the text using \Q...\E
+            String regex = "\\Q" + wildcardPattern.replace("*", "\\E.*\\Q") + "\\E";
+            // strip off unnecessary \\Q\\E in case * appeared at beginning or end of part
+            regex = regex.replace("\\Q\\E", "");
+            return Pattern.compile(regex);
+        }
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/Strings.java
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/java/org/glowroot/agent/plugin/jakartaservlet/_/Strings.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.jakartaservlet._;
+
+import org.glowroot.agent.plugin.api.checker.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Strings {
+
+    private Strings() {}
+
+    public static String nullToEmpty(@Nullable String string) {
+        return string == null ? "" : string;
+    }
+
+    public static List<String> split(String string, char c) {
+        List<String> list = new ArrayList<String>();
+        int lastFoundIndex = -1;
+        int nextFoundIndex;
+        while ((nextFoundIndex = string.indexOf(c, lastFoundIndex + 1)) != -1) {
+            String value = string.substring(lastFoundIndex + 1, nextFoundIndex).trim();
+            if (!value.isEmpty()) {
+                list.add(value);
+            }
+            lastFoundIndex = nextFoundIndex;
+        }
+        String value = string.substring(lastFoundIndex + 1).trim();
+        if (!value.isEmpty()) {
+            list.add(value);
+        }
+        return list;
+    }
+}

--- a/agent/plugins/jakarta-servlet-plugin/src/main/resources/META-INF/glowroot.plugin.json
+++ b/agent/plugins/jakarta-servlet-plugin/src/main/resources/META-INF/glowroot.plugin.json
@@ -1,0 +1,186 @@
+{
+  "name": "Jakarta Servlet Plugin",
+  "id": "jakartaservlet",
+  "properties": [
+    {
+      "name": "sessionUserAttribute",
+      "type": "string",
+      "label": "Session user attribute",
+      "description": "Session attribute to capture as the user of the trace. Traces can be filtered by user in the explorer. Nested paths are supported, e.g. something.user.username. The attribute value is converted into a String if necessary via toString(). The special attribute name '::id' can be used to refer to the http session id."
+    },
+    {
+      "name": "captureSessionAttributes",
+      "type": "list",
+      "label": "Session attributes",
+      "description": "List of servlet session attributes to capture in the root trace entry. Nested paths are supported, e.g. mainObject.nestedObject.displayName. '*' at the end of a path is supported, e.g. mainObject.nestedObject.*, meaning capture all properties of mainObject.nestedObject (via reflection, looking at methods that begin with \"get[A-Z]\" or \"is[A-Z]\"). '*' by itself means capture all session attributes. Values are converted into Strings if necessary via toString(). The special attribute name '::id' can be used to refer to the http session id."
+    },
+    {
+      "name": "captureRequestParameters",
+      "type": "list",
+      "default": [
+        "*"
+      ],
+      "label": "Capture request parameters",
+      "description": "List of request parameters to capture in the root trace entry. The wildcard '*' is supported anywhere in the parameter name."
+    },
+    {
+      "name": "maskRequestParameters",
+      "type": "list",
+      "default": [
+        "*password*",
+        "*token*",
+        "*access*",
+        "*secret*"
+      ],
+      "label": "Mask request parameters",
+      "description": "List of sensitive request parameters to mask, e.g. passwords. The wildcard '*' is supported anywhere in the parameter name."
+    },
+    {
+      "name": "captureRequestHeaders",
+      "type": "list",
+      "label": "Capture request headers",
+      "description": "List of request headers to capture in the root trace entry. The wildcard '*' is supported anywhere in the header name."
+    },
+    {
+      "name": "captureResponseHeaders",
+      "type": "list",
+      "label": "Capture response headers",
+      "description": "List of response headers to capture in the root trace entry. The wildcard '*' is supported anywhere in the header name."
+    },
+    {
+      "name": "traceErrorOn4xxResponseCode",
+      "type": "boolean",
+      "label": "Error on 4xx",
+      "checkboxLabel": "Mark trace as error on 4xx response code",
+      "description": "Mark the trace as an error when a 4xx response code is returned."
+    },
+    {
+      "name": "captureRequestRemoteAddr",
+      "type": "boolean",
+      "label": "Capture request remote address",
+      "checkboxLabel": "Capture request remote address using ServletRequest.getRemoteAddr()"
+    },
+    {
+      "name": "captureRequestRemoteHostname",
+      "type": "boolean",
+      "label": "Capture request remote hostname",
+      "checkboxLabel": "Capture request remote hostname using ServletRequest.getRemoteHost()"
+    },
+    {
+      "name": "captureRequestRemotePort",
+      "type": "boolean",
+      "label": "Capture request remote port",
+      "checkboxLabel": "Capture request remote port using ServletRequest.getRemotePort()",
+      "description": "This only applies to Servlet 3.0+ containers."
+    },
+    {
+      "name": "captureRequestLocalAddr",
+      "type": "boolean",
+      "label": "Capture request local address",
+      "checkboxLabel": "Capture request local address using ServletRequest.getLocalAddr()",
+      "description": "This only applies to Servlet 3.0+ containers."
+    },
+    {
+      "name": "captureRequestLocalHostname",
+      "type": "boolean",
+      "label": "Capture request local hostname",
+      "checkboxLabel": "Capture request local hostname using ServletRequest.getLocalName()",
+      "description": "This only applies to Servlet 3.0+ containers."
+    },
+    {
+      "name": "captureRequestLocalPort",
+      "type": "boolean",
+      "label": "Capture request local port",
+      "checkboxLabel": "Capture request local port using ServletRequest.getLocalPort()",
+      "description": "This only applies to Servlet 3.0+ containers."
+    },
+    {
+      "name": "captureRequestServerHostname",
+      "type": "boolean",
+      "label": "Capture request server hostname",
+      "checkboxLabel": "Capture request server hostname using ServletRequest.getServerName()"
+    },
+    {
+      "name": "captureRequestServerPort",
+      "type": "boolean",
+      "label": "Capture request server port",
+      "checkboxLabel": "Capture request server port using ServletRequest.getServerPort()"
+    }
+  ],
+  "instrumentation": [
+    {
+      "className": "jakarta.servlet.ServletContextListener",
+      "methodName": "contextInitialized",
+      "methodParameterTypes": [
+        "jakarta.servlet.ServletContextEvent"
+      ],
+      "captureKind": "transaction",
+      "timerName": "listener init",
+      "transactionType": "Startup",
+      "transactionNameTemplate": "Listener init: {{this.class.name}}"
+    },
+    {
+      "className": "jakarta.servlet.Servlet",
+      "methodName": "init",
+      "methodParameterTypes": [
+        "jakarta.servlet.ServletConfig"
+      ],
+      "captureKind": "transaction",
+      "timerName": "servlet init",
+      "transactionType": "Startup",
+      "transactionNameTemplate": "Servlet init: {{this.class.name}}"
+    },
+    {
+      "className": "jakarta.servlet.Filter",
+      "methodName": "init",
+      "methodParameterTypes": [
+        "jakarta.servlet.FilterConfig"
+      ],
+      "captureKind": "transaction",
+      "timerName": "filter init",
+      "transactionType": "Startup",
+      "transactionNameTemplate": "Filter init: {{this.class.name}}"
+    },
+    {
+      "className": "jakarta.servlet.ServletContainerInitializer",
+      "methodName": "onStartup",
+      "methodParameterTypes": [
+        "java.util.Set",
+        "jakarta.servlet.ServletContext"
+      ],
+      "captureKind": "transaction",
+      "timerName": "container initializer",
+      "transactionType": "Startup",
+      "transactionNameTemplate": "Container initializer: {{this.class.name}}"
+    },
+    {
+      "className": "org.wildfly.extension.undertow.deployment.UndertowDeploymentService",
+      "methodName": "startContext",
+      "methodParameterTypes": [
+      ],
+      "captureKind": "transaction",
+      "timerName": "application startup",
+      "transactionType": "Startup",
+      "transactionNameTemplate": "Servlet context: {{this.deploymentInfoInjectedValue.value.contextPath}}"
+    },
+    {
+      "className": "org.eclipse.jetty.webapp.WebAppContext",
+      "methodName": "doStart",
+      "methodParameterTypes": [
+      ],
+      "captureKind": "transaction",
+      "timerName": "application startup",
+      "transactionType": "Startup",
+      "transactionNameTemplate": "Servlet context: {{this.contextPath}}"
+    }
+  ],
+  "aspects": [
+    "org.glowroot.agent.plugin.jakartaservlet.ServletAspect",
+    "org.glowroot.agent.plugin.jakartaservlet.AsyncServletAspect",
+    "org.glowroot.agent.plugin.jakartaservlet.RequestParameterAspect",
+    "org.glowroot.agent.plugin.jakartaservlet.ResponseHeaderAspect",
+    "org.glowroot.agent.plugin.jakartaservlet.RequestDispatcherAspect",
+    "org.glowroot.agent.plugin.jakartaservlet.SessionAspect"
+  ],
+  "collocate": true
+}

--- a/agent/plugins/jaxrs-plugin/src/main/java/org/glowroot/agent/plugin/jaxrs/ResourceAspect.java
+++ b/agent/plugins/jaxrs-plugin/src/main/java/org/glowroot/agent/plugin/jaxrs/ResourceAspect.java
@@ -39,8 +39,10 @@ public class ResourceAspect {
     private static final BooleanProperty useAltTransactionNaming =
             Agent.getConfigService("jaxrs").getBooleanProperty("useAltTransactionNaming");
 
-    @Pointcut(methodAnnotation = "javax.ws.rs.Path|javax.ws.rs.DELETE|javax.ws.rs.GET"
-            + "|javax.ws.rs.HEAD|javax.ws.rs.OPTIONS|javax.ws.rs.POST|javax.ws.rs.PUT",
+    @Pointcut(methodAnnotation = "javax.ws.rs.Path|jakarta.ws.rs.Path|javax.ws.rs.DELETE|jakarta.ws.rs.DELETE" +
+            "|javax.ws.rs.GET|jakarta.ws.rs.GET|javax.ws.rs.HEAD|jakarta.ws.rs.HEAD" +
+            "|javax.ws.rs.OPTIONS|jakarta.ws.rs.OPTIONS|javax.ws.rs.POST|jakarta.ws.rs.POST" +
+            "|javax.ws.rs.PUT|jakarta.ws.rs.PUT",
             methodParameterTypes = {".."}, timerName = "jaxrs resource", nestingGroup = "jaxrs")
     public static class ResourceAdvice {
 

--- a/agent/plugins/jaxrs-plugin/src/main/java/org/glowroot/agent/plugin/jaxrs/ResourceMethodMeta.java
+++ b/agent/plugins/jaxrs-plugin/src/main/java/org/glowroot/agent/plugin/jaxrs/ResourceMethodMeta.java
@@ -89,7 +89,8 @@ public class ResourceMethodMeta {
         try {
             for (Annotation annotation : clazz.getDeclaredAnnotations()) {
                 Class<?> annotationClass = annotation.annotationType();
-                if (annotationClass.getName().equals("javax.ws.rs.Path")) {
+                if (annotationClass.getName().equals("javax.ws.rs.Path") ||
+                        annotationClass.getName().equals("jakarta.ws.rs.Path")) {
                     return getPathAttribute(annotationClass, annotation, "value");
                 }
             }
@@ -133,7 +134,8 @@ public class ResourceMethodMeta {
             boolean hasHttpMethodAnnotation = false;
             for (Annotation annotation : method.getDeclaredAnnotations()) {
                 Class<?> annotationClass = annotation.annotationType();
-                if (annotationClass.getName().equals("javax.ws.rs.Path")) {
+                if (annotationClass.getName().equals("javax.ws.rs.Path") ||
+                        annotationClass.getName().equals("jakarta.ws.rs.Path")) {
                     pathAnnotation = getPathAttribute(annotationClass, annotation, "value");
                 } else if (isHttpMethodAnnotation(annotationClass)) {
                     hasHttpMethodAnnotation = true;
@@ -151,7 +153,8 @@ public class ResourceMethodMeta {
     private static boolean isHttpMethodAnnotation(Class<?> annotationClass) {
         for (Annotation annotation : annotationClass.getDeclaredAnnotations()) {
             Class<?> metaClass = annotation.annotationType();
-            if (metaClass.getName().equals("javax.ws.rs.HttpMethod")) {
+            if (metaClass.getName().equals("javax.ws.rs.HttpMethod") ||
+                    metaClass.getName().equals("jakarta.ws.rs.HttpMethod")) {
                 return true;
             }
         }

--- a/agent/plugins/jms-plugin/src/main/resources/META-INF/glowroot.plugin.json
+++ b/agent/plugins/jms-plugin/src/main/resources/META-INF/glowroot.plugin.json
@@ -3,10 +3,10 @@
   "id": "jms",
   "instrumentation": [
     {
-      "className": "javax.jms.MessageListener",
+      "className": "javax.jms.MessageListener|jakarta.jms.MessageListener",
       "methodName": "onMessage",
       "methodParameterTypes": [
-        "javax.jms.Message"
+        "javax.jms.Message|jakarta.jms.Message"
       ],
       "nestingGroup": "jms",
       "captureKind": "transaction",
@@ -15,10 +15,10 @@
       "transactionNameTemplate": "JMS Message: {{this.class.simpleName}}"
     },
     {
-      "className": "javax.jms.MessageProducer",
+      "className": "javax.jms.MessageProducer|jakarta.jms.MessageProducer",
       "methodName": "send",
       "methodParameterTypes": [
-        "javax.jms.Message",
+        "javax.jms.Message|jakarta.jms.Message",
         ".."
       ],
       "nestingGroup": "jms",
@@ -26,11 +26,11 @@
       "timerName": "jms send message"
     },
     {
-      "className": "javax.jms.MessageProducer",
+      "className": "javax.jms.MessageProducer|jakarta.jms.MessageProducer",
       "methodName": "send",
       "methodParameterTypes": [
-        "javax.jms.Destination",
-        "javax.jms.Message",
+        "javax.jms.Destination|jakarta.jms.Destination",
+        "javax.jms.Message|jakarta.jms.Message",
         ".."
       ],
       "nestingGroup": "jms",

--- a/agent/plugins/jsf-plugin/src/main/resources/META-INF/glowroot.plugin.json
+++ b/agent/plugins/jsf-plugin/src/main/resources/META-INF/glowroot.plugin.json
@@ -6,7 +6,7 @@
       "className": "com.sun.faces.lifecycle.ApplyRequestValuesPhase",
       "methodName": "execute",
       "methodParameterTypes": [
-        "javax.faces.context.FacesContext"
+        "javax.faces.context.FacesContext|jakarta.faces.context.FacesContext"
       ],
       "nestingGroup": "jsf",
       "captureKind": "trace-entry",
@@ -17,7 +17,7 @@
       "className": "com.sun.faces.application.ActionListenerImpl",
       "methodName": "processAction",
       "methodParameterTypes": [
-        "javax.faces.event.ActionEvent"
+        "javax.faces.event.ActionEvent|jakarta.faces.event.ActionEvent"
       ],
       "nestingGroup": "jsf",
       "captureKind": "trace-entry",
@@ -28,7 +28,7 @@
       "className": "com.sun.faces.lifecycle.RenderResponsePhase",
       "methodName": "execute",
       "methodParameterTypes": [
-        "javax.faces.context.FacesContext"
+        "javax.faces.context.FacesContext|jakarta.faces.context.FacesContext"
       ],
       "nestingGroup": "jsf",
       "captureKind": "trace-entry",

--- a/agent/plugins/jsp-plugin/src/main/java/org/glowroot/agent/plugin/jsp/HttpJspPageAspect.java
+++ b/agent/plugins/jsp-plugin/src/main/java/org/glowroot/agent/plugin/jsp/HttpJspPageAspect.java
@@ -30,9 +30,9 @@ import org.glowroot.agent.plugin.api.weaving.Pointcut;
 
 public class HttpJspPageAspect {
 
-    @Pointcut(className = "javax.servlet.jsp.HttpJspPage", methodName = "_jspService",
-            methodParameterTypes = {"javax.servlet.http.HttpServletRequest",
-                    "javax.servlet.http.HttpServletResponse"},
+    @Pointcut(className = "javax.servlet.jsp.HttpJspPage|jakarta.servlet.jsp.HttpJspPage", methodName = "_jspService",
+            methodParameterTypes = {"javax.servlet.http.HttpServletRequest|jakarta.servlet.http.HttpServletRequest",
+                    "javax.servlet.http.HttpServletResponse|jakarta.servlet.http.HttpServletResponse"},
             nestingGroup = "jsp", timerName = "jsp render")
     public static class HttpJspPageAdvice {
 

--- a/agent/plugins/spring-plugin/src/main/java/org/glowroot/agent/plugin/spring/ControllerAspect.java
+++ b/agent/plugins/spring-plugin/src/main/java/org/glowroot/agent/plugin/spring/ControllerAspect.java
@@ -140,7 +140,7 @@ public class ControllerAspect {
 
     @Pointcut(className = "org.springframework.web.servlet.handler.AbstractHandlerMethodMapping",
             methodName = "handleMatch", methodParameterTypes = {"java.lang.Object",
-                    "java.lang.String", "javax.servlet.http.HttpServletRequest"})
+                    "java.lang.String", "javax.servlet.http.HttpServletRequest|jakarta.servlet.http.HttpServletRequest"})
     public static class HandlerMethodMappingAdvice {
         @OnBefore
         public static void onBefore(ThreadContext context,
@@ -175,7 +175,7 @@ public class ControllerAspect {
 
     @Pointcut(className = "org.springframework.web.servlet.handler.AbstractUrlHandlerMapping",
             methodName = "exposePathWithinMapping", methodParameterTypes = {"java.lang.String",
-                    "java.lang.String", "javax.servlet.http.HttpServletRequest"})
+                    "java.lang.String", "javax.servlet.http.HttpServletRequest|jakarta.servlet.http.HttpServletRequest"})
     public static class UrlHandlerMappingAdvice {
         @OnBefore
         public static void onBefore(ThreadContext context,

--- a/agent/plugins/spring-plugin/src/main/resources/META-INF/glowroot.plugin.json
+++ b/agent/plugins/spring-plugin/src/main/resources/META-INF/glowroot.plugin.json
@@ -26,8 +26,8 @@
       "className": "org.springframework.jms.listener.SessionAwareMessageListener",
       "methodName": "onMessage",
       "methodParameterTypes": [
-        "javax.jms.Message",
-        "javax.jms.Session"
+        "javax.jms.Message|jakarta.jms.Message",
+        "javax.jms.Session|jakarta.jms.Session"
       ],
       "nestingGroup": "jms",
       "captureKind": "transaction",

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
     <module>agent/plugins/grails-plugin</module>
     <module>agent/plugins/hibernate-plugin</module>
     <module>agent/plugins/http-client-plugin</module>
+    <module>agent/plugins/jakarta-servlet-plugin</module>
     <module>agent/plugins/java-http-server-plugin</module>
     <module>agent/plugins/jaxrs-plugin</module>
     <module>agent/plugins/jaxws-plugin</module>


### PR DESCRIPTION
Dear @trask 
here is a PR that aims at making glowroot works with apps using `jakarta.*` instead of `javax.*` package.

This point has been discussed here: https://github.com/glowroot/glowroot/discussions/976 
Since most package have been renamed from `javax.*` to `jakarta.*`, most of the weaving does not work anymore.

This PR tries to address this, mostly by adapting all the regexp and code to handle `jakarta.*`.

As for the `servlet-plugin`, I had no choice but to create a new plugin.

With all these changes, I am now able to monitor the web part of a spring boot 3.x application. 
