### PR TITLE
fix(sec): upgrade io.netty:netty-codec-http to 4.1.86.final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <protobuf.version>3.21.12</protobuf.version>
     <protoc.version>3.21.12</protoc.version>
     <!-- need to stick to netty version that is used by grpc version above -->
-    <netty.version>4.1.79.Final</netty.version>
+    <netty.version>4.1.86.final</netty.version>
     <logback.version>1.2.11</logback.version>
     <slf4j.version>1.7.36</slf4j.version>
     <immutables.version>2.8.8</immutables.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-codec-http 4.1.79.Final
- [CVE-2022-41915](https://www.oscs1024.com/hd/CVE-2022-41915)


### What did I do？
Upgrade io.netty:netty-codec-http from 4.1.79.Final to 4.1.86.final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS