### PR TITLE
fix(sec): upgrade org.springframework:spring-web to 6.0.0

### DIFF
--- a/agent/benchmarks/pom.xml
+++ b/agent/benchmarks/pom.xml
@@ -36,7 +36,7 @@
       <!-- this jar file is used by WeavingBenchmark -->
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>5.3.23</version>
+      <version>6.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>

--- a/agent/plugins/http-client-plugin/pom.xml
+++ b/agent/plugins/http-client-plugin/pom.xml
@@ -28,7 +28,7 @@
     <okhttpclient.version>4.9.2</okhttpclient.version>
     <okhttpclient2x.version>2.7.5</okhttpclient2x.version>
     <cxf.version>3.4.5</cxf.version>
-    <spring.version>5.3.23</spring.version>
+    <spring.version>6.0.0</spring.version>
     <axis.version>1.4</axis.version>
   </properties>
 

--- a/agent/plugins/servlet-plugin/pom.xml
+++ b/agent/plugins/servlet-plugin/pom.xml
@@ -72,7 +72,7 @@
         org.springframework.mock.web.MockHttpServletRequest -->
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>5.3.23</version>
+      <version>6.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-web 5.3.23
- [CVE-2016-1000027](https://www.oscs1024.com/hd/CVE-2016-1000027)


### What did I do？
Upgrade org.springframework:spring-web from 5.3.23 to 6.0.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS