### PR TITLE
fix(sec): upgrade org.hsqldb:hsqldb to 2.7.1

### DIFF
--- a/agent/benchmarks/pom.xml
+++ b/agent/benchmarks/pom.xml
@@ -51,7 +51,7 @@
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <!-- version 2.6+ require Java 11 -->
-      <version>2.5.2</version>
+      <version>2.7.1</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/agent/plugins/hibernate-plugin/pom.xml
+++ b/agent/plugins/hibernate-plugin/pom.xml
@@ -55,7 +55,7 @@
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <!-- version 2.6+ require Java 11 -->
-      <version>2.5.2</version>
+      <version>2.7.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/agent/plugins/jdbc-plugin/pom.xml
+++ b/agent/plugins/jdbc-plugin/pom.xml
@@ -20,7 +20,7 @@
     <!-- instrumented libraries -->
     <h2.version>1.4.200</h2.version>
     <!-- version 2.6+ require Java 11 -->
-    <hsqldb.version>2.5.2</hsqldb.version>
+    <hsqldb.version>2.7.1</hsqldb.version>
     <postgresql.version>42.2.24.jre7</postgresql.version>
     <mssql.version>9.4.0.jre8</mssql.version>
     <commons.dbcp.version>1.4</commons.dbcp.version>

--- a/webdriver-tests/pom.xml
+++ b/webdriver-tests/pom.xml
@@ -152,7 +152,7 @@
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <!-- version 2.6+ require Java 11 -->
-      <version>2.5.2</version>
+      <version>2.7.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.hsqldb:hsqldb 2.5.2
- [CVE-2022-41853](https://www.oscs1024.com/hd/CVE-2022-41853)


### What did I do？
Upgrade org.hsqldb:hsqldb from 2.5.2 to 2.7.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS