### PR TITLE
Fix suggestion for #960

### DIFF
--- a/common2/src/main/java/org/glowroot/common2/repo/util/AlertingService.java
+++ b/common2/src/main/java/org/glowroot/common2/repo/util/AlertingService.java
@@ -458,7 +458,7 @@ public class AlertingService {
         message.setSubject(subj);
         message.setText(messageText);
         mailService.send(message);
-    }    
+    }
 
     public static String getPreUpperBoundText(boolean ok) {
         if (ok) {

--- a/common2/src/main/java/org/glowroot/common2/repo/util/AlertingService.java
+++ b/common2/src/main/java/org/glowroot/common2/repo/util/AlertingService.java
@@ -345,7 +345,7 @@ public class AlertingService {
                 sendEmail(centralDisplay, agentRollupDisplay, subject,
                         emailNotification.getEmailAddressList(),
                         messageText, smtpConfig, null, configRepository.getLazySecretKey(),
-                        mailService);
+                        mailService, ok);
             }
         }
         PagerDutyNotification pagerDutyNotification = alertNotification.getPagerDutyNotification();
@@ -421,8 +421,8 @@ public class AlertingService {
     // org.glowroot.common.repo.util.LazySecretKey.SymmetricEncryptionKeyMissingException
     public static void sendEmail(String centralDisplay, String agentRollupDisplay, String subject,
             List<String> emailAddresses, String messageText, SmtpConfig smtpConfig,
-            @Nullable String passwordOverride, LazySecretKey lazySecretKey, MailService mailService)
-            throws Exception {
+            @Nullable String passwordOverride, LazySecretKey lazySecretKey, MailService mailService, 
+            boolean ok) throws Exception {
         Session session = createMailSession(smtpConfig, passwordOverride, lazySecretKey);
         Message message = new MimeMessage(session);
         String fromEmailAddress = smtpConfig.fromEmailAddress();
@@ -450,10 +450,15 @@ public class AlertingService {
         if (agentRollupDisplay.isEmpty() && centralDisplay.isEmpty()) {
             subj = "[Glowroot] " + subj;
         }
+        if (ok) {
+            subj = subj + " - resolved";
+        } else {
+            subj = subj + " - triggered";
+        }
         message.setSubject(subj);
         message.setText(messageText);
         mailService.send(message);
-    }
+    }    
 
     public static String getPreUpperBoundText(boolean ok) {
         if (ok) {

--- a/ui/src/main/java/org/glowroot/ui/AdminJsonService.java
+++ b/ui/src/main/java/org/glowroot/ui/AdminJsonService.java
@@ -509,7 +509,7 @@ class AdminJsonService {
             String subject = "Test email";
             AlertingService.sendEmail(centralDisplay, agentDisplay, subject, emailAddresses, "",
                     configDtoWithoutNewPassword.convert(configRepository), passwordOverride,
-                    configRepository.getLazySecretKey(), mailService);
+                    configRepository.getLazySecretKey(), mailService, true);
         } catch (Exception e) {
             logger.debug(e.getMessage(), e);
             return createErrorResponse(e);

--- a/ui/src/test/java/org/glowroot/ui/AdminJsonServiceTest.java
+++ b/ui/src/test/java/org/glowroot/ui/AdminJsonServiceTest.java
@@ -73,7 +73,7 @@ public class AdminJsonServiceTest {
         assertThat(message.getFrom()[0].toString()).isEqualTo("From Example <from@example.org>");
         assertThat(message.getRecipients(Message.RecipientType.TO)[0].toString())
                 .isEqualTo("to@example.org");
-        assertThat(message.getSubject()).isEqualTo("[Glowroot] Test email");
+        assertThat(message.getSubject()).isEqualTo("[Glowroot] Test email - resolved");
         assertThat(message.getContent()).isEqualTo("");
     }
 
@@ -98,7 +98,7 @@ public class AdminJsonServiceTest {
                 .isEqualTo("From Example <glowroot@" + localHostname + ">");
         assertThat(message.getRecipients(Message.RecipientType.TO)[0].toString())
                 .isEqualTo("to@example.org");
-        assertThat(message.getSubject()).isEqualTo("[Glowroot] Test email");
+        assertThat(message.getSubject()).isEqualTo("[Glowroot] Test email - resolved");
         assertThat(message.getContent()).isEqualTo("");
     }
 
@@ -123,7 +123,7 @@ public class AdminJsonServiceTest {
                 .isEqualTo("Glowroot <glowroot@" + localHostname + ">");
         assertThat(message.getRecipients(Message.RecipientType.TO)[0].toString())
                 .isEqualTo("to@example.org");
-        assertThat(message.getSubject()).isEqualTo("[Glowroot] Test email");
+        assertThat(message.getSubject()).isEqualTo("[Glowroot] Test email - resolved");
         assertThat(message.getContent()).isEqualTo("");
     }
 


### PR DESCRIPTION
Hello,

I simply added " - triggered" or " - resolved" to the end of e-mail's subject regarding the status. Similar feature is already implemented for PagerDuty and Slack alerts.

Although it is not configurable, it would address the requirements listed #960.

Note: I work in an enterprise environment and it is nearly impossible to retrive artifacts and compile the project. (Enterprise Maven repo setting, proxy setting, proxy certificate problems, SSL handshake problems, node-14.21.X-win-x64.zip package downloading problems, missing node.exe execution grants in Maven target directory, conflict with the node installation on the machine etc.) Because, I was only able to compile Java modules -by skipping tests- and failed to compile ui part, there could be other dependencies which I could not aware of.

Regards,

Ali Sadik Kumlali