### PR TITLE
Fix again #1072 UnsupportedOperationException in embedded collector

### DIFF
--- a/ui/src/main/java/org/glowroot/ui/TransactionCommonService.java
+++ b/ui/src/main/java/org/glowroot/ui/TransactionCommonService.java
@@ -227,6 +227,7 @@ class TransactionCommonService {
                 }
             }).thenApply(orderedNonRolledUpAggregates -> {
                 if (liveResult != null) {
+                    orderedNonRolledUpAggregates = Lists.newArrayList(orderedNonRolledUpAggregates);
                     orderedNonRolledUpAggregates.addAll(liveResult.get());
                 }
                 List<PercentileAggregate> aggregatesInner = Lists.newArrayList(finalAggregates);


### PR DESCRIPTION
Hello, 
On a fresh install of latest 0.14.5-beta release, I faced the following exception while clicking on "percentile" radio button : 

```
2025-08-08 12:27:29.786 ERROR o.g.a.e.s.o.g.ui.CommonHandler - java.lang.UnsupportedOperationException
java.util.concurrent.ExecutionException: java.lang.UnsupportedOperationException
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073)
	at org.glowroot.agent.embedded.shaded.org.glowroot.ui.TransactionJsonService.getPercentiles(TransactionJsonService.java:156)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.glowroot.agent.embedded.shaded.org.glowroot.ui.CommonHandler.callMethod(CommonHandler.java:585)
	at org.glowroot.agent.embedded.shaded.org.glowroot.ui.CommonHandler.handleJsonServiceMappings(CommonHandler.java:324)
	at org.glowroot.agent.embedded.shaded.org.glowroot.ui.CommonHandler.handleRequest(CommonHandler.java:235)
	at org.glowroot.agent.embedded.shaded.org.glowroot.ui.CommonHandler.handle(CommonHandler.java:159)
	at org.glowroot.agent.embedded.shaded.org.glowroot.ui.HttpServerHandler.channelRead(HttpServerHandler.java:128)
	at org.glowroot.agent.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at org.glowroot.agent.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at org.glowroot.agent.shaded.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at org.glowroot.agent.shaded.io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at org.glowroot.agent.shaded.io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:111)
	at org.glowroot.agent.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at org.glowroot.agent.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at org.glowroot.agent.shaded.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at org.glowroot.agent.shaded.io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at org.glowroot.agent.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at org.glowroot.agent.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at org.glowroot.agent.shaded.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at org.glowroot.agent.shaded.io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436)
	at org.glowroot.agent.shaded.io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at org.glowroot.agent.shaded.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
	at org.glowroot.agent.shaded.io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
	at org.glowroot.agent.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at org.glowroot.agent.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at org.glowroot.agent.shaded.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at org.glowroot.agent.shaded.io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1407)
	at org.glowroot.agent.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at org.glowroot.agent.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at org.glowroot.agent.shaded.io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at org.glowroot.agent.shaded.io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at org.glowroot.agent.shaded.io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
	at org.glowroot.agent.shaded.io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
	at org.glowroot.agent.shaded.io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
	at org.glowroot.agent.shaded.io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
	at org.glowroot.agent.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994)
	at org.glowroot.agent.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.UnsupportedOperationException: null
	at org.glowroot.agent.shaded.com.google.common.collect.ImmutableCollection.addAll(ImmutableCollection.java:297)
	at org.glowroot.agent.embedded.shaded.org.glowroot.ui.TransactionCommonService.lambda$getPercentileAggregates$6(TransactionCommonService.java:230)
	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:684)
	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:662)
	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2200)
	at org.glowroot.agent.embedded.shaded.org.glowroot.ui.TransactionCommonService.lambda$getPercentileAggregates$7(TransactionCommonService.java:228)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2341)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:144)
	at org.glowroot.agent.embedded.shaded.org.glowroot.ui.TransactionCommonService.getPercentileAggregates(TransactionCommonService.java:203)
	... 39 common frames omitted
```

This issue was supposed to be already fixed (  #1072 ) but it appears that one occurence was not treated.
