### PR TITLE
Exclude classes from weaving via a system property

### DIFF
--- a/agent/core/src/main/java/org/glowroot/agent/weaving/WeavingClassFileTransformer.java
+++ b/agent/core/src/main/java/org/glowroot/agent/weaving/WeavingClassFileTransformer.java
@@ -22,6 +22,7 @@ import java.security.ProtectionDomain;
 import java.util.Collections;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.regex.Pattern;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
@@ -31,6 +32,9 @@ public class WeavingClassFileTransformer implements ClassFileTransformer {
 
     private static final boolean ALLOW_WEAVING_AGENT_CLASSES =
             Boolean.getBoolean("glowroot.internal.allowWeavingAgentClasses");
+
+    private static final Pattern EXCLUDE_CLASSES_FROM_WEAVING_PATTERN =
+            Pattern.compile(System.getProperty("glowroot.weaving.excludeClasses", ""));
 
     private static final Logger logger = LoggerFactory.getLogger(WeavingClassFileTransformer.class);
 
@@ -146,6 +150,12 @@ public class WeavingClassFileTransformer implements ClassFileTransformer {
         if (className.equals("load/C4") && loader != null && loader.getClass().getName()
                 .equals("oracle.classloader.util.ClassLoadEnvironment$DependencyLoader")) {
             // special case to avoid weaving error when running OC4J
+            return true;
+        }
+
+
+        if (EXCLUDE_CLASSES_FROM_WEAVING_PATTERN.matcher(className).matches()){
+            //Let the user exclude troublesome classes.
             return true;
         }
         return false;


### PR DESCRIPTION
In OSGi environments weaving can fail due to classloading visibility issues. It is useful to be able to exclude some classes from weaving to avoid errors during startup.

One such case is the weaving of Pax-Web in Karaf 4.4.6, Pax web includes subclasses (PaxWebSessionHandler) of Jetty classes (org.eclipse.jetty.util.component.ContainerLifeCycle). The jetty classes aren't visible to the pax classe's classloader - so we get an error 

```
 ERROR org.glowroot.agent.weaving.Weaver - error analyzing org/ops4j/pax/web/service/jetty/internal/PaxWebSessionHandler: org.eclipse.jetty.util.component.ContainerLifeCycle
java.lang.ClassNotFoundException: org.eclipse.jetty.util.component.ContainerLifeCycle
```

Rather than investing a lot of effort in handling OSGi classloading I propose a  simple system property to specify classes that are excluded from wevaing.
