### PR TITLE
Sidebar order by total transaction count

### DIFF
--- a/agent/embedded/src/main/java/org/glowroot/agent/embedded/repo/AggregateDao.java
+++ b/agent/embedded/src/main/java/org/glowroot/agent/embedded/repo/AggregateDao.java
@@ -818,6 +818,7 @@ public class AggregateDao implements AggregateRepository {
                     return "sum(total_duration_nanos) desc";
                 case AVERAGE_TIME:
                     return "sum(total_duration_nanos) / sum(transaction_count) desc";
+                case TOTAL_TRANSACTION_COUNT:
                 case THROUGHPUT:
                     return "sum(transaction_count) desc";
                 case TOTAL_CPU_TIME:

--- a/common/src/main/java/org/glowroot/common/model/TransactionNameSummaryCollector.java
+++ b/common/src/main/java/org/glowroot/common/model/TransactionNameSummaryCollector.java
@@ -136,6 +136,7 @@ public class TransactionNameSummaryCollector {
                 return orderingByTotalTimeDesc.immutableSortedCopy(transactionNameSummaries);
             case AVERAGE_TIME:
                 return orderingByAverageTimeDesc.immutableSortedCopy(transactionNameSummaries);
+            case TOTAL_TRANSACTION_COUNT:
             case THROUGHPUT:
                 return orderingByTransactionCountDesc.immutableSortedCopy(transactionNameSummaries);
             case TOTAL_CPU_TIME:
@@ -152,7 +153,7 @@ public class TransactionNameSummaryCollector {
     }
 
     public enum SummarySortOrder {
-        TOTAL_TIME, AVERAGE_TIME, THROUGHPUT, TOTAL_CPU_TIME, AVERAGE_CPU_TIME, TOTAL_ALLOCATED_MEMORY, AVERAGE_ALLOCATED_MEMORY
+        TOTAL_TIME, AVERAGE_TIME, THROUGHPUT, TOTAL_CPU_TIME, AVERAGE_CPU_TIME, TOTAL_ALLOCATED_MEMORY, AVERAGE_ALLOCATED_MEMORY, TOTAL_TRANSACTION_COUNT
     }
 
     @Value.Immutable

--- a/ui/app/scripts/routes.js
+++ b/ui/app/scripts/routes.js
@@ -183,7 +183,8 @@ glowroot.config([
             'total-cpu-time': 'By total CPU time (%)',
             'average-cpu-time': 'By average CPU time',
             'total-allocated-memory': 'By total allocated memory (%)',
-            'average-allocated-memory': 'By average allocated memory'
+            'average-allocated-memory': 'By average allocated memory',
+            'total-transaction-count': 'By total transaction count'
           };
         },
         summaryValueFn: [
@@ -206,6 +207,8 @@ glowroot.config([
                 return (100 * summary.totalAllocatedBytes / overallSummary.totalAllocatedBytes).toFixed(1) + ' %';
               } else if (sortOrder === 'average-allocated-memory') {
                 return $filter('gtBytes')(summary.totalAllocatedBytes / summary.transactionCount);
+              } else if (sortOrder === 'total-transaction-count') {
+                  return summary.transactionCount;
               } else {
                 // unexpected sort order
                 return '';


### PR DESCRIPTION
Added support for ordering by total transaction count. Same aggregation as throughput, but not divided by selected duration filter.

<img width="481" height="589" alt="image" src="https://github.com/user-attachments/assets/e70b5c0d-4f05-4fe7-8780-0cc0834c7fa0" />
