### PR TITLE
Fix invalid bytecode generation in weaving generics by using Object instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.idea

--- a/agent/core/src/main/java/org/glowroot/agent/weaving/WeavingClassVisitor.java
+++ b/agent/core/src/main/java/org/glowroot/agent/weaving/WeavingClassVisitor.java
@@ -633,7 +633,7 @@ class WeavingClassVisitor extends ClassVisitor {
         }
         List<Advice> advisors = removeSuperseded(inheritedMethod.advisors());
         MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, inheritedMethod.name(),
-                inheritedMethod.getDesc(), inheritedMethod.signature(), exceptions);
+                inheritedMethod.getDesc(), null, exceptions);
         mv = visitMethodWithAdvice(mv, ACC_PUBLIC, inheritedMethod.name(),
                 inheritedMethod.getDesc(), advisors);
         checkNotNull(mv);


### PR DESCRIPTION
Weaving with generics was generating invalid bytecode.
This change replaces the generic type with Object to ensure valid bytecode generation.

Fixes: #977