### PR TITLE
Make jackson max-nesting-depth configurable

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -44,9 +44,10 @@ jobs:
         with:
           path: |
             ~/.m2/repository
-            ~/.cache/bower
-          key: build-test${{ matrix.testGroup }}-${{ hashFiles('**/pom.xml') }}
+            ~/.npm
+          key: build-test${{ matrix.testGroup }}-${{ hashFiles('**/pom.xml', 'ui/package.json') }}
           restore-keys: |
+            build-test${{ matrix.testGroup }}-
             build-
 
       - name: Build

--- a/central/src/main/conf/glowroot-central.properties
+++ b/central/src/main/conf/glowroot-central.properties
@@ -86,3 +86,8 @@ jgroups.symEncryptKeystoreName=
 jgroups.symEncryptKeystorePassword=
 jgroups.symEncryptKeyAlias=
 jgroups.symEncryptKeyPassword=
+
+# default is 1000
+# Allows to set a bigger nesting size for Jackson StreamWriteConstraints
+# to prevent an exception on exports and flamegraphs when trace is too big
+jackson.max.nesting.depth=

--- a/ui/app/index.html
+++ b/ui/app/index.html
@@ -284,7 +284,7 @@
 <script src="node_modules/codemirror/lib/codemirror.js"></script>
 <script src="node_modules/codemirror/mode/clike/clike.js"></script>
 <script src="node_modules/codemirror/addon/edit/matchbrackets.js"></script>
-<script src="node_modules/angular-ui-codemirror/ui-codemirror.js"></script>
+<script src="node_modules/angular-ui-codemirror/src/ui-codemirror.js"></script>
 <!-- angular-ui-bootstrap4-templates.js is generated at build time by grunt-angular-templates -->
 <script src="scripts/generated/angular-ui-bootstrap4-templates.js"></script>
 <script src="node_modules/focus-visible/src/focus-visible.js"></script>

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "angular": "1.7.9",
     "angular-sanitize": "1.7.9",
-    "angular-ui-bootstrap4": "Morgul/ui-bootstrap4#v3.0.5",
+    "ui-bootstrap4": "Morgul/ui-bootstrap4#v3.0.5",
     "angular-ui-codemirror": "0.3.0",
     "angular-ui-router": "1.0.20",
     "bootstrap": "4.2.1",


### PR DESCRIPTION
Allows to set a bigger value for max nesting depth on StreamWriteContraints to prevent an exception on exports and flamegraphs when trace is too big.

See https://github.com/glowroot/glowroot/issues/1122

I also fixed a mvn compilation issue on my linux os behind a proxy by using protocArtifact instead of protocVersion.

See https://github.com/os72/protoc-jar-maven-plugin/issues/68#issuecomment-455267366