### PR TITLE
Clarify response time chart vs breakdown table (#1158)

### DIFF
--- a/ui/app/scripts/controllers/transaction/average.js
+++ b/ui/app/scripts/controllers/transaction/average.js
@@ -100,8 +100,19 @@ glowroot.controller('TransactionAverageCtrl', [
       // indent1 must be sync'd with $indent1 variable in common-trace.less
       var indent1 = 8.41; // px
 
+      function selfNanos(timer) {
+        var nested = 0;
+        if (timer.childTimers) {
+          angular.forEach(timer.childTimers, function (childTimer) {
+            nested += childTimer.totalNanos;
+          });
+        }
+        return timer.totalNanos - nested;
+      }
+
       function traverse(timer, nestingLevel) {
         timer.nestingIndent = nestingLevel * indent1 * 2;
+        timer.selfNanos = selfNanos(timer);
         treeTimers.push(timer);
         if (timer.childTimers) {
           timer.childTimers.sort(function (a, b) {
@@ -132,12 +143,24 @@ glowroot.controller('TransactionAverageCtrl', [
       var flattenedTimerMap = {};
       var flattenedTimers = [];
 
+      function selfNanos(timer) {
+        var nested = 0;
+        if (timer.childTimers) {
+          $.each(timer.childTimers, function (index, nestedTimer) {
+            nested += nestedTimer.totalNanos;
+          });
+        }
+        return timer.totalNanos - nested;
+      }
+
       function traverse(timer, parentTimerNames) {
+        var leafNanos = selfNanos(timer);
         var flattenedTimer = flattenedTimerMap[timer.name];
         if (!flattenedTimer) {
           flattenedTimer = {
             name: timer.name,
             totalNanos: timer.totalNanos,
+            selfNanos: leafNanos,
             count: timer.extended ? 0 : timer.count
           };
           flattenedTimerMap[timer.name] = flattenedTimer;
@@ -146,6 +169,7 @@ glowroot.controller('TransactionAverageCtrl', [
           // only add to existing flattened timer if the aggregate timer isn't appearing under itself
           // (this is possible when they are separated by another aggregate timer)
           flattenedTimer.totalNanos += timer.totalNanos;
+          flattenedTimer.selfNanos += leafNanos;
           if (!timer.extended) {
             flattenedTimer.count += timer.count;
           }

--- a/ui/app/template/gt-timer-display.html
+++ b/ui/app/template/gt-timer-display.html
@@ -6,6 +6,7 @@
     <tr>
       <td class="gt-breakdown-header gt-bold" style="text-align: left;">{{heading}}</td>
       <td class="gt-breakdown-header" style="font-weight: 600;">total&nbsp;(ms)</td>
+      <td class="gt-breakdown-header" style="font-weight: 600;">self&nbsp;(ms)</td>
       <td class="gt-breakdown-header" style="font-weight: 600;">count</td>
     </tr>
     </thead>
@@ -18,10 +19,11 @@
         </div>
       </td>
       <td>{{flattenedTimer.totalNanos / (1000000 * transactionCount) | gtMillis}}</td>
+      <td>{{flattenedTimer.selfNanos / (1000000 * transactionCount) | gtMillis}}</td>
       <td>{{flattenedTimer.count / transactionCount | gtCount}}</td>
     </tr>
     <tr class="align-top">
-      <td colspan="3" style="text-align: left;">
+      <td colspan="4" style="text-align: left;">
         <div class="gt-indent2">
           <div style="margin-left: -6px;">
             <span tabindex="-1"></span>
@@ -63,6 +65,7 @@
     <tr>
       <td class="gt-breakdown-header gt-bold" style="text-align: left;">{{heading}}</td>
       <td class="gt-breakdown-header" style="font-weight: 600;">total&nbsp;(ms)</td>
+      <td class="gt-breakdown-header" style="font-weight: 600;">self&nbsp;(ms)</td>
       <td class="gt-breakdown-header" style="font-weight: 600;">count</td>
     </tr>
     </thead>
@@ -77,10 +80,11 @@
         </div>
       </td>
       <td>{{treeTimer.totalNanos / (1000000 * transactionCount) | gtMillis}}</td>
+      <td>{{treeTimer.selfNanos / (1000000 * transactionCount) | gtMillis}}</td>
       <td>{{treeTimer.count / transactionCount | gtCount}}</td>
     </tr>
     <tr class="align-top">
-      <td colspan="3" style="text-align: left;">
+      <td colspan="4" style="text-align: left;">
         <div class="gt-indent2">
           <div style="margin-left: -6px;">
             <span tabindex="-1"></span>

--- a/ui/app/template/help/average-chart.html
+++ b/ui/app/template/help/average-chart.html
@@ -1,16 +1,12 @@
-<div style="margin: 10px; width: 280px;">
+<div style="margin: 10px; width: 200px; box-sizing: border-box; word-wrap: break-word; overflow-wrap: break-word;">
   <div><strong>Chart navigation tips</strong></div>
-  <ul style="margin-left: -13px;">
+  <ul style="padding-left: 18px; margin: 6px 0 0 0;">
     <li>drag or double click to zoom in</li>
     <li>use ctrl + scroll wheel to zoom in and out</li>
   </ul>
-  <div style="margin-top: 12px;"><strong>Chart vs breakdown</strong></div>
-  <ul style="margin-left: -13px; margin-bottom: 0;">
-    <li>the chart stacks each timer's <em>self time</em>
-      (exclusive time, not including nested timers); the stack height is the
-      average response time</li>
-    <li>the breakdown <em>total</em> column is <em>inclusive</em> average time
-      (parents include nested timers); use the <em>self</em> column to compare
-      with chart segments. Inclusive rows do not need to add up to the chart total</li>
+  <div style="margin-top: 10px;"><strong>Chart vs breakdown</strong></div>
+  <ul style="padding-left: 18px; margin: 6px 0 0 0;">
+    <li>chart stacks <em>self time</em> (exclusive); stack height is average response time</li>
+    <li>breakdown <em>total</em> is inclusive; use <em>self</em> to compare with chart segments</li>
   </ul>
 </div>

--- a/ui/app/template/help/average-chart.html
+++ b/ui/app/template/help/average-chart.html
@@ -1,0 +1,16 @@
+<div style="margin: 10px; width: 280px;">
+  <div><strong>Chart navigation tips</strong></div>
+  <ul style="margin-left: -13px;">
+    <li>drag or double click to zoom in</li>
+    <li>use ctrl + scroll wheel to zoom in and out</li>
+  </ul>
+  <div style="margin-top: 12px;"><strong>Chart vs breakdown</strong></div>
+  <ul style="margin-left: -13px; margin-bottom: 0;">
+    <li>the chart stacks each timer's <em>self time</em>
+      (exclusive time, not including nested timers); the stack height is the
+      average response time</li>
+    <li>the breakdown <em>total</em> column is <em>inclusive</em> average time
+      (parents include nested timers); use the <em>self</em> column to compare
+      with chart segments. Inclusive rows do not need to add up to the chart total</li>
+  </ul>
+</div>

--- a/ui/app/views/transaction/average.html
+++ b/ui/app/views/transaction/average.html
@@ -70,7 +70,7 @@
     </span>
   </button>
   <button class="gt-chart-button"
-          uib-popover-template="'template/help/chart.html'"
+          uib-popover-template="'template/help/average-chart.html'"
           popover-placement="left"
           popover-trigger="'outsideClick'">
     <span title="Help"
@@ -119,6 +119,12 @@
   <div ng-if="mergedAggregate.transactionCount"
        class="gt-everything-below-average-chart"
        style="position: relative; padding-top: 30px;">
+    <div style="color: #555; font-size: 12px; margin-bottom: 12px; max-width: 640px;">
+      The chart shows stacked <em>self time</em> (exclusive). The breakdown table's
+      <em>total</em> column is inclusive (parents include nested timers); compare the
+      <em>self</em> column to the chart segments. Inclusive totals do not need to sum to
+      the chart total.
+    </div>
     <div ng-if="mainThreadFlattenedTimers.length">
       <div gt-timer-display
            heading="Breakdown{{auxThreadFlattenedTimers.length ? ' (Main Thread)' : ''}}:"

--- a/ui/src/main/java/org/glowroot/ui/StackedTimerTotals.java
+++ b/ui/src/main/java/org/glowroot/ui/StackedTimerTotals.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.ui;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.glowroot.common.live.LiveAggregateRepository.OverviewAggregate;
+import org.glowroot.wire.api.model.AggregateOuterClass.Aggregate;
+
+/**
+ * Builds stacked (leaf / self-time) timer totals used by the transaction average chart.
+ *
+ * <p>Self time for a timer is {@code totalNanos - sum(child.totalNanos)}. Chart series use these
+ * exclusive values so stacked segments add up to average response time. The breakdown table uses
+ * inclusive {@code totalNanos} instead, which is why parent timer rows often look larger than their
+ * chart segments (see issue #1158).
+ */
+class StackedTimerTotals {
+
+    private StackedTimerTotals() {}
+
+    static Map<String, Double> create(OverviewAggregate overviewAggregate) {
+        Map<String, Double> stackedTimers = new HashMap<String, Double>();
+        for (Aggregate.Timer rootTimer : overviewAggregate.mainThreadRootTimers()) {
+            // skip root timers — root self-time becomes the chart "other" bucket
+            for (Aggregate.Timer topLevelTimer : rootTimer.getChildTimerList()) {
+                addToStackedTimer(topLevelTimer, stackedTimers);
+            }
+        }
+        return stackedTimers;
+    }
+
+    static double selfNanos(Aggregate.Timer timer) {
+        double totalNestedNanos = 0;
+        for (Aggregate.Timer childTimer : timer.getChildTimerList()) {
+            totalNestedNanos += childTimer.getTotalNanos();
+        }
+        return timer.getTotalNanos() - totalNestedNanos;
+    }
+
+    /**
+     * Whether an aggregate capture time belongs in the merged breakdown for the selected chart
+     * range (same filter as {@link TransactionJsonService#getOverview}).
+     */
+    static boolean captureTimeInMergedRange(long captureTime, long from, long to) {
+        return captureTime > from && captureTime <= to;
+    }
+
+    private static void addToStackedTimer(Aggregate.Timer timer, Map<String, Double> stackedTimers) {
+        for (Aggregate.Timer childTimer : timer.getChildTimerList()) {
+            addToStackedTimer(childTimer, stackedTimers);
+        }
+        String timerName = timer.getName();
+        Double existing = stackedTimers.get(timerName);
+        double leafNanos = selfNanos(timer);
+        if (existing == null) {
+            stackedTimers.put(timerName, leafNanos);
+        } else {
+            stackedTimers.put(timerName, existing + leafNanos);
+        }
+    }
+}

--- a/ui/src/main/java/org/glowroot/ui/TransactionJsonService.java
+++ b/ui/src/main/java/org/glowroot/ui/TransactionJsonService.java
@@ -17,7 +17,6 @@ package org.glowroot.ui;
 
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -124,7 +123,8 @@ class TransactionJsonService {
         List<OverviewAggregate> overviewAggregatesForMerging = Lists.newArrayList();
         for (OverviewAggregate overviewAggregate : overviewAggregates) {
             long captureTime = overviewAggregate.captureTime();
-            if (captureTime > request.from() && captureTime <= request.to()) {
+            if (StackedTimerTotals.captureTimeInMergedRange(captureTime, request.from(),
+                    request.to())) {
                 overviewAggregatesForMerging.add(overviewAggregate);
             }
         }
@@ -723,7 +723,10 @@ class TransactionJsonService {
         DataSeriesHelper dataSeriesHelper =
                 new DataSeriesHelper(liveCaptureTime, dataPointIntervalMillis);
         final int topX = 5;
-        List<String> timerNames = getTopTimerNames(stackedPoints, topX + 1);
+        // Rank top timers using the same capture-time window as the breakdown table, so out-of-range
+        // slope points (fetched only for chart edge sloping) do not skew the series selection.
+        List<String> timerNames = getTopTimerNames(stackedPoints, topX + 1, request.from(),
+                request.to());
         List<DataSeries> dataSeriesList = Lists.newArrayList();
         for (int i = 0; i < Math.min(timerNames.size(), topX); i++) {
             dataSeriesList.add(new DataSeries(timerNames.get(i)));
@@ -742,18 +745,18 @@ class TransactionJsonService {
                 dataSeriesHelper.addGapIfNeeded(priorOverviewAggregate.captureTime(),
                         overviewAggregate.captureTime(), dataSeriesList, otherDataSeries);
             }
-            MutableDoubleMap<String> stackedTimers = stackedPoint.getStackedTimers();
+            Map<String, Double> stackedTimers = stackedPoint.getStackedTimers();
             double totalOtherNanos = overviewAggregate.totalDurationNanos();
             for (DataSeries dataSeries : dataSeriesList) {
-                MutableDouble totalNanos = stackedTimers.get(dataSeries.getName());
+                Double totalNanos = stackedTimers.get(dataSeries.getName());
                 if (totalNanos == null) {
                     dataSeries.add(overviewAggregate.captureTime(), 0);
                 } else {
                     // convert to average milliseconds
-                    double value = (totalNanos.doubleValue() / overviewAggregate.transactionCount())
+                    double value = (totalNanos / overviewAggregate.transactionCount())
                             / NANOSECONDS_PER_MILLISECOND;
                     dataSeries.add(overviewAggregate.captureTime(), value);
-                    totalOtherNanos -= totalNanos.doubleValue();
+                    totalOtherNanos -= totalNanos;
                 }
             }
             if (overviewAggregate.transactionCount() == 0) {
@@ -795,29 +798,37 @@ class TransactionJsonService {
     }
 
     // calculate top 5 timers
-    private static List<String> getTopTimerNames(List<StackedPoint> stackedPoints, int topX) {
-        MutableDoubleMap<String> timerTotals = new MutableDoubleMap<String>();
+    private static List<String> getTopTimerNames(List<StackedPoint> stackedPoints, int topX,
+            long from, long to) {
+        Map<String, Double> timerTotals = Maps.newHashMap();
         for (StackedPoint stackedPoint : stackedPoints) {
-            for (Map.Entry<String, MutableDouble> entry : stackedPoint.getStackedTimers()
-                    .entrySet()) {
-                timerTotals.add(entry.getKey(), entry.getValue().doubleValue());
+            if (!StackedTimerTotals.captureTimeInMergedRange(
+                    stackedPoint.getOverviewAggregate().captureTime(), from, to)) {
+                continue;
+            }
+            for (Map.Entry<String, Double> entry : stackedPoint.getStackedTimers().entrySet()) {
+                Double existing = timerTotals.get(entry.getKey());
+                if (existing == null) {
+                    timerTotals.put(entry.getKey(), entry.getValue());
+                } else {
+                    timerTotals.put(entry.getKey(), existing + entry.getValue());
+                }
             }
         }
-        Ordering<Map.Entry<String, MutableDouble>> valueOrdering =
+        Ordering<Map.Entry<String, Double>> valueOrdering =
                 Ordering.natural()
-                        .onResultOf(new Function<Map.Entry<String, MutableDouble>, Double>() {
+                        .onResultOf(new Function<Map.Entry<String, Double>, Double>() {
                             @Override
-                            public Double apply(
-                                    Map. /*@Nullable*/ Entry<String, MutableDouble> entry) {
+                            public Double apply(Map. /*@Nullable*/ Entry<String, Double> entry) {
                                 checkNotNull(entry);
-                                return entry.getValue().doubleValue();
+                                return entry.getValue();
                             }
                         });
         List<String> timerNames = Lists.newArrayList();
         @SuppressWarnings("assignment.type.incompatible")
-        List<Map.Entry<String, MutableDouble>> topTimerTotals =
+        List<Map.Entry<String, Double>> topTimerTotals =
                 valueOrdering.greatestOf(timerTotals.entrySet(), topX);
-        for (Map.Entry<String, MutableDouble> entry : topTimerTotals) {
+        for (Map.Entry<String, Double> entry : topTimerTotals) {
             timerNames.add(entry.getKey());
         }
         return timerNames;
@@ -827,22 +838,14 @@ class TransactionJsonService {
 
         private final OverviewAggregate overviewAggregate;
         // stacked timer values only include time spent as a leaf node in the timer tree
-        private final MutableDoubleMap<String> stackedTimers;
+        private final Map<String, Double> stackedTimers;
 
         private static StackedPoint create(OverviewAggregate overviewAggregate) {
-            MutableDoubleMap<String> stackedTimers = new MutableDoubleMap<String>();
-            for (Aggregate.Timer rootTimer : overviewAggregate.mainThreadRootTimers()) {
-                // skip root timers
-                for (Aggregate.Timer topLevelTimer : rootTimer.getChildTimerList()) {
-                    // traverse tree starting at top-level (under root) timers
-                    addToStackedTimer(topLevelTimer, stackedTimers);
-                }
-            }
-            return new StackedPoint(overviewAggregate, stackedTimers);
+            return new StackedPoint(overviewAggregate, StackedTimerTotals.create(overviewAggregate));
         }
 
         private StackedPoint(OverviewAggregate overviewAggregate,
-                MutableDoubleMap<String> stackedTimers) {
+                Map<String, Double> stackedTimers) {
             this.overviewAggregate = overviewAggregate;
             this.stackedTimers = stackedTimers;
         }
@@ -851,43 +854,8 @@ class TransactionJsonService {
             return overviewAggregate;
         }
 
-        private MutableDoubleMap<String> getStackedTimers() {
+        private Map<String, Double> getStackedTimers() {
             return stackedTimers;
-        }
-
-        private static void addToStackedTimer(Aggregate.Timer timer,
-                MutableDoubleMap<String> stackedTimers) {
-            double totalNestedNanos = 0;
-            for (Aggregate.Timer childTimer : timer.getChildTimerList()) {
-                totalNestedNanos += childTimer.getTotalNanos();
-                addToStackedTimer(childTimer, stackedTimers);
-            }
-            String timerName = timer.getName();
-            stackedTimers.add(timerName, timer.getTotalNanos() - totalNestedNanos);
-        }
-    }
-
-    // by using MutableDouble, two operations (get/put) are not required for each increment,
-    // instead just a single get is needed (except for first delta)
-    @SuppressWarnings("serial")
-    private static class MutableDoubleMap<K> extends HashMap<K, MutableDouble> {
-        private void add(K key, double delta) {
-            MutableDouble existing = get(key);
-            if (existing == null) {
-                put(key, new MutableDouble(delta));
-            } else {
-                existing.value += delta;
-            }
-        }
-    }
-
-    private static class MutableDouble {
-        private double value;
-        private MutableDouble(double value) {
-            this.value = value;
-        }
-        private double doubleValue() {
-            return value;
         }
     }
 

--- a/ui/src/test/java/org/glowroot/ui/StackedTimerTotalsTest.java
+++ b/ui/src/test/java/org/glowroot/ui/StackedTimerTotalsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.ui;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.glowroot.common.live.ImmutableOverviewAggregate;
+import org.glowroot.common.live.LiveAggregateRepository.OverviewAggregate;
+import org.glowroot.wire.api.model.AggregateOuterClass.Aggregate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StackedTimerTotalsTest {
+
+    @Test
+    public void leafOnlyTimerMatchesInclusiveTotal() {
+        Aggregate.Timer leaf = Aggregate.Timer.newBuilder()
+                .setName("jdbc")
+                .setTotalNanos(5_000_000)
+                .setCount(1)
+                .build();
+        Aggregate.Timer root = Aggregate.Timer.newBuilder()
+                .setName("http request")
+                .setTotalNanos(5_000_000)
+                .setCount(1)
+                .addChildTimer(leaf)
+                .build();
+
+        OverviewAggregate aggregate = overview(1000, 5_000_000, 1, root);
+
+        Map<String, Double> stacked = StackedTimerTotals.create(aggregate);
+
+        // Chart skips the root timer; leaf self-time equals inclusive total when there are no
+        // nested children under jdbc.
+        assertThat(stacked).containsOnlyKeys("jdbc");
+        assertThat(stacked.get("jdbc")).isEqualTo(5_000_000);
+        assertThat(StackedTimerTotals.selfNanos(leaf)).isEqualTo(leaf.getTotalNanos());
+    }
+
+    @Test
+    public void parentSelfPlusChildEqualsInclusiveParent() {
+        Aggregate.Timer child = Aggregate.Timer.newBuilder()
+                .setName("jdbc")
+                .setTotalNanos(4_000_000)
+                .setCount(1)
+                .build();
+        Aggregate.Timer parent = Aggregate.Timer.newBuilder()
+                .setName("http")
+                .setTotalNanos(10_000_000)
+                .setCount(1)
+                .addChildTimer(child)
+                .build();
+        Aggregate.Timer root = Aggregate.Timer.newBuilder()
+                .setName("http request")
+                .setTotalNanos(10_000_000)
+                .setCount(1)
+                .addChildTimer(parent)
+                .build();
+
+        OverviewAggregate aggregate = overview(1000, 10_000_000, 1, root);
+        Map<String, Double> stacked = StackedTimerTotals.create(aggregate);
+
+        double httpSelf = stacked.get("http");
+        double jdbcSelf = stacked.get("jdbc");
+
+        assertThat(httpSelf).isEqualTo(6_000_000); // exclusive / chart segment
+        assertThat(jdbcSelf).isEqualTo(4_000_000);
+        // Inclusive parent (breakdown table) = chart(parent self) + chart(child self)
+        assertThat(httpSelf + jdbcSelf).isEqualTo(parent.getTotalNanos());
+        assertThat(StackedTimerTotals.selfNanos(parent)).isEqualTo(httpSelf);
+    }
+
+    @Test
+    public void captureTimeFilterMatchesBreakdownMergeWindow() {
+        assertThat(StackedTimerTotals.captureTimeInMergedRange(1000, 1000, 2000)).isFalse();
+        assertThat(StackedTimerTotals.captureTimeInMergedRange(1001, 1000, 2000)).isTrue();
+        assertThat(StackedTimerTotals.captureTimeInMergedRange(2000, 1000, 2000)).isTrue();
+        assertThat(StackedTimerTotals.captureTimeInMergedRange(2001, 1000, 2000)).isFalse();
+    }
+
+    private static OverviewAggregate overview(long captureTime, double totalDurationNanos,
+            long transactionCount, Aggregate.Timer rootTimer) {
+        return ImmutableOverviewAggregate.builder()
+                .captureTime(captureTime)
+                .totalDurationNanos(totalDurationNanos)
+                .transactionCount(transactionCount)
+                .asyncTransactions(false)
+                .addMainThreadRootTimers(rootTimer)
+                .mainThreadStats(Aggregate.ThreadStats.getDefaultInstance())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Document that the Transactions average chart stacks **self time** (exclusive) while the breakdown **total** column is **inclusive**, which often looks like a mismatch (#1158).
- Add a **self (ms)** column to the breakdown table so values are comparable to chart segments.
- Extract `StackedTimerTotals` with unit tests for the leaf/self-time relationship, and rank chart top timers using the same capture-time window as the breakdown merge (ignore out-of-range slope points).

## Test plan
- [x] `mvn test -Dtest=StackedTimerTotalsTest -pl :glowroot-ui -Dglowroot.ui.skip`
- [x] Open Transactions → average: help `?` explains chart vs breakdown
- [x] Confirm note under chart and new **self** column in flattened/tree views
- [x] Parent+child timers: `self(parent) + self(child) ≈ total(parent)`
- [x] Leaf-only timer: self equals total and matches chart segment
