### PR TITLE
Fix exported trace sharedQueryText index scramble (#1181)

### DIFF
--- a/central/src/main/java/org/glowroot/central/repo/SharedQueryTextsForExport.java
+++ b/central/src/main/java/org/glowroot/central/repo/SharedQueryTextsForExport.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.central.repo;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import org.glowroot.wire.api.model.TraceOuterClass.Trace;
+
+/**
+ * Resolves full query texts for trace export while preserving
+ * {@code sharedQueryTextIndex} order used by entries and query stats.
+ */
+final class SharedQueryTextsForExport {
+
+    private SharedQueryTextsForExport() {}
+
+    /**
+     * @param getFullText maps fullTextSha1 → full text (null if expired / missing)
+     */
+    static CompletionStage<List<Trace.SharedQueryText>> resolve(
+            List<Trace.SharedQueryText> sharedQueryTexts,
+            Function<String, CompletionStage<String>> getFullText) {
+        List<Trace.SharedQueryText> resolved =
+                new ArrayList<>(Collections.nCopies(sharedQueryTexts.size(), null));
+        List<CompletableFuture<?>> futures = new ArrayList<>();
+        for (int i = 0; i < sharedQueryTexts.size(); i++) {
+            Trace.SharedQueryText sharedQueryText = sharedQueryTexts.get(i);
+            String fullTextSha1 = sharedQueryText.getFullTextSha1();
+            if (fullTextSha1.isEmpty()) {
+                resolved.set(i, sharedQueryText);
+            } else {
+                final int index = i;
+                futures.add(getFullText.apply(fullTextSha1).thenAccept(fullText -> {
+                    if (fullText == null) {
+                        resolved.set(index, Trace.SharedQueryText.newBuilder()
+                                .setFullText(sharedQueryText.getTruncatedText()
+                                        + " ... [full query text has expired] ... "
+                                        + sharedQueryText.getTruncatedEndText())
+                                .build());
+                    } else {
+                        resolved.set(index, Trace.SharedQueryText.newBuilder()
+                                .setFullText(fullText)
+                                .build());
+                    }
+                }).toCompletableFuture());
+            }
+        }
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .thenApply(ignored -> resolved);
+    }
+}

--- a/central/src/main/java/org/glowroot/central/repo/TraceDaoImpl.java
+++ b/central/src/main/java/org/glowroot/central/repo/TraceDaoImpl.java
@@ -54,7 +54,6 @@ import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
@@ -1097,32 +1096,14 @@ public class TraceDaoImpl implements TraceDao {
                         })
                 .thenCompose(entries -> {
                     return readSharedQueryTexts(agentId, traceId, profile).thenCompose(sht -> {
-                        List<Trace.SharedQueryText> sharedQueryTexts = new ArrayList<>();
-                        List<Future<?>> futures = new ArrayList<>();
-                        for (Trace.SharedQueryText sharedQueryText : sht) {
-                            String fullTextSha1 = sharedQueryText.getFullTextSha1();
-                            if (fullTextSha1.isEmpty()) {
-                                sharedQueryTexts.add(sharedQueryText);
-                            } else {
-                                futures.add(fullQueryTextDao.getFullText(agentId, fullTextSha1, profile).thenAccept(fullText -> {
-                                    if (fullText == null) {
-                                        sharedQueryTexts.add(Trace.SharedQueryText.newBuilder()
-                                                .setFullText(sharedQueryText.getTruncatedText()
-                                                        + " ... [full query text has expired] ... "
-                                                        + sharedQueryText.getTruncatedEndText())
-                                                .build());
-                                    } else {
-                                        sharedQueryTexts.add(Trace.SharedQueryText.newBuilder()
-                                                .setFullText(fullText)
-                                                .build());
-                                    }
-                                }).toCompletableFuture());
-                            }
-                        }
-                        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).thenApply(ignored -> {
-                            return entries.addAllSharedQueryTexts(sharedQueryTexts)
-                                    .build();
-                        });
+                        // Preserve original index order — see SharedQueryTextsForExport / issue #1181.
+                        return SharedQueryTextsForExport
+                                .resolve(sht,
+                                        fullTextSha1 -> fullQueryTextDao.getFullText(agentId,
+                                                fullTextSha1, profile))
+                                .thenApply(sharedQueryTexts -> entries
+                                        .addAllSharedQueryTexts(sharedQueryTexts)
+                                        .build());
                     });
                 });
 

--- a/central/src/test/java/org/glowroot/central/repo/SharedQueryTextsForExportTest.java
+++ b/central/src/test/java/org/glowroot/central/repo/SharedQueryTextsForExportTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.central.repo;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+import org.glowroot.wire.api.model.TraceOuterClass.Trace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SharedQueryTextsForExportTest {
+
+    @Test
+    public void preservesIndexOrderWhenAsyncResolutionCompletesOutOfOrder() throws Exception {
+        Trace.SharedQueryText inline0 = Trace.SharedQueryText.newBuilder()
+                .setFullText("select a")
+                .build();
+        Trace.SharedQueryText sha1 = Trace.SharedQueryText.newBuilder()
+                .setTruncatedText("select b start")
+                .setTruncatedEndText("end")
+                .setFullTextSha1("sha-b")
+                .build();
+        Trace.SharedQueryText inline2 = Trace.SharedQueryText.newBuilder()
+                .setFullText("select c")
+                .build();
+
+        // Slow resolution for index 1 so it finishes after index 2 would have been reachable —
+        // the old ArrayList.add()-on-complete path scrambled order here.
+        CompletionStage<List<Trace.SharedQueryText>> stage = SharedQueryTextsForExport.resolve(
+                ImmutableList.of(inline0, sha1, inline2),
+                fullTextSha1 -> CompletableFuture.supplyAsync(() -> {
+                    try {
+                        Thread.sleep(50);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return "select b full";
+                }));
+
+        List<Trace.SharedQueryText> resolved = stage.toCompletableFuture().get(2, TimeUnit.SECONDS);
+
+        assertThat(resolved).hasSize(3);
+        assertThat(resolved.get(0).getFullText()).isEqualTo("select a");
+        assertThat(resolved.get(1).getFullText()).isEqualTo("select b full");
+        assertThat(resolved.get(2).getFullText()).isEqualTo("select c");
+    }
+
+    @Test
+    public void expiredFullTextKeepsSlotAndUsesTruncatedFallback() throws Exception {
+        Trace.SharedQueryText sha1 = Trace.SharedQueryText.newBuilder()
+                .setTruncatedText("head")
+                .setTruncatedEndText("tail")
+                .setFullTextSha1("missing")
+                .build();
+        Trace.SharedQueryText inline = Trace.SharedQueryText.newBuilder()
+                .setFullText("inline")
+                .build();
+
+        List<Trace.SharedQueryText> resolved = SharedQueryTextsForExport
+                .resolve(ImmutableList.of(sha1, inline),
+                        fullTextSha1 -> CompletableFuture.completedFuture(null))
+                .toCompletableFuture()
+                .get(2, TimeUnit.SECONDS);
+
+        assertThat(resolved.get(0).getFullText())
+                .isEqualTo("head ... [full query text has expired] ... tail");
+        assertThat(resolved.get(1).getFullText()).isEqualTo("inline");
+    }
+}


### PR DESCRIPTION
## Summary
- Central trace **export** rebuilt `sharedQueryTexts` by appending as async full-text lookups completed (and mixing sync inline texts), so `sharedQueryTextIndex` on entries/query stats pointed at the wrong SQL while bind params stayed on the original entry.
- Live UI was fine because it keeps Cassandra order and loads full text by SHA-1 without reordering.
- Unrelated to #1152 (agent `PreparedStatementMirror` bind-parameter snapshot).
- Extract `SharedQueryTextsForExport` with unit tests for out-of-order completion and expired full text.

## Test plan
- [x] `mvn test -Dtest=SharedQueryTextsForExportTest -pl :glowroot-central`
- [ ] Central + Cassandra: multi-query trace (mix short + long/SHA-1 texts) — compare live Trace entries / Query stats vs exported HTML
- [ ] Confirm summary sections still match
- [ ] Expired full-query-text case still shows truncated fallback message

## Verification limitation (local)
We could **not** run an end-to-end central + Cassandra environment locally to validate the export path against a live UI (no hypervisor/virtualization available on this Windows machine, so Docker/Cassandra was not an option). Embedded UI sandbox does not exercise this code path.

What we did validate locally:
- Unit tests covering out-of-order async resolution and expired full-text fallback
- Code review of `TraceDaoImpl.readEntriesAndQueriesForExport` vs the sequential embedded export path

An E2E check on a real central + Cassandra setup (live vs exported HTML for a multi-query trace) would still be appreciated from anyone who can run that stack.