### PR TITLE
[FEATURE] Lean Storage defaults under Maintenance

### DIFF
--- a/ui/app/index.html
+++ b/ui/app/index.html
@@ -310,6 +310,7 @@
 <script src="scripts/services/query-strings.js"></script>
 <script src="scripts/services/conversions.js"></script>
 <script src="scripts/services/instrumentation-export.js"></script>
+<script src="scripts/services/deployment-presets.js"></script>
 <script src="scripts/controllers/navbar.js"></script>
 <script src="scripts/controllers/chart-range.js"></script>
 <script src="scripts/controllers/transaction.js"></script>
@@ -356,6 +357,7 @@
 <script src="scripts/controllers/config/instrumentation-list.js"></script>
 <script src="scripts/controllers/config/instrumentation.js"></script>
 <script src="scripts/controllers/config/advanced.js"></script>
+<script src="scripts/controllers/config/deployment-profile.js"></script>
 <script src="scripts/controllers/config/json.js"></script>
 <script src="scripts/controllers/admin.js"></script>
 <script src="scripts/controllers/admin/general.js"></script>

--- a/ui/app/scripts/controllers/config/deployment-profile.js
+++ b/ui/app/scripts/controllers/config/deployment-profile.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* global glowroot, angular */
+/* global glowroot, angular, console */
 
 glowroot.controller('ConfigDeploymentProfileCtrl', [
   '$scope',
@@ -34,14 +34,41 @@ glowroot.controller('ConfigDeploymentProfileCtrl', [
       return;
     }
 
+    var LOG_PREFIX = '[Glowroot deployment profile]';
+
+    function logInfo() {
+      // Help operators/reviewers see load → preview → sequential Save without guessing
+      var args = Array.prototype.slice.call(arguments);
+      args.unshift(LOG_PREFIX);
+      console.info.apply(console, args);
+    }
+
+    function logWarn() {
+      var args = Array.prototype.slice.call(arguments);
+      args.unshift(LOG_PREFIX);
+      console.warn.apply(console, args);
+    }
+
     $scope.page = {};
     $scope.profile = 'custom';
+    // Profile matching the last loaded/saved config (not the preview dropdown)
+    $scope.activeProfile = 'custom';
     $scope.loaded = false;
 
     var originalStorage;
     var originalTransaction;
     var originalAdvanced;
     var originalPage;
+
+    $scope.profileDisplayName = function (name) {
+      if (name === 'dev') {
+        return 'Dev';
+      }
+      if (name === 'prod') {
+        return 'Prod';
+      }
+      return 'Custom';
+    };
 
     $scope.canEdit = function () {
       return $scope.layout.adminEdit
@@ -105,24 +132,38 @@ glowroot.controller('ConfigDeploymentProfileCtrl', [
       };
     }
 
-    function matchedProfileName() {
-      if ($scope.page.rollupCappedSizesNonUniform) {
+    function matchedProfileName(page) {
+      if (!page) {
         return 'custom';
       }
-      return deploymentPresets.matchName($scope.page);
+      if (page.rollupCappedSizesNonUniform) {
+        return 'custom';
+      }
+      return deploymentPresets.matchName(page);
     }
 
     function syncProfileSelect() {
-      $scope.profile = matchedProfileName();
+      $scope.profile = matchedProfileName($scope.page);
+    }
+
+    function syncActiveProfile() {
+      $scope.activeProfile = matchedProfileName(originalPage);
     }
 
     $scope.onProfileChange = function () {
       if ($scope.profile === 'custom') {
+        // No draft restore — Custom keeps the current form values;
+        // activeProfile still shows what is currently saved.
+        logInfo('profile select → Custom (form unchanged; active saved profile still',
+            $scope.activeProfile + ')');
         return;
       }
       // Populate only — does not persist until Save
+      logInfo('profile select →', $scope.profile,
+          '(populate preview only; active saved profile still', $scope.activeProfile + ')');
       deploymentPresets.apply($scope.profile, $scope.page);
       $scope.page.rollupCappedSizesNonUniform = false;
+      logInfo('preview values applied', angular.copy($scope.page));
     };
 
     $scope.$watch('page', function () {
@@ -130,8 +171,9 @@ glowroot.controller('ConfigDeploymentProfileCtrl', [
         return;
       }
       // Keep dropdown in sync when user edits fields manually
-      var matched = matchedProfileName();
+      var matched = matchedProfileName($scope.page);
       if ($scope.profile !== matched) {
+        logInfo('form edit changed matched profile', $scope.profile, '→', matched);
         $scope.profile = matched;
       }
     }, true);
@@ -143,7 +185,10 @@ glowroot.controller('ConfigDeploymentProfileCtrl', [
       $scope.page = pageFromLoaded(storage, originalTransaction, advanced);
       originalPage = angular.copy($scope.page);
       syncProfileSelect();
+      syncActiveProfile();
       $scope.loaded = true;
+      logInfo('loaded; active=', $scope.activeProfile, 'select=', $scope.profile,
+          'values=', angular.copy($scope.page));
     }
 
     $scope.save = function (deferred) {
@@ -169,25 +214,35 @@ glowroot.controller('ConfigDeploymentProfileCtrl', [
       advancedPayload.maxTraceEntriesPerTransaction = $scope.page.maxTraceEntriesPerTransaction;
       advancedPayload.maxProfileSamplesPerTransaction = $scope.page.maxProfileSamplesPerTransaction;
 
+      logInfo('Save starting (sequential storage → transaction → advanced); preview profile=',
+          $scope.profile, 'active before save=', $scope.activeProfile);
+
       // Sequential: stop on first failure so we never claim full success after a partial apply
       $http.post('backend/admin/storage', storagePayload)
           .then(function (storageResponse) {
             originalStorage = storageResponse.data;
+            logInfo('POST admin/storage OK');
             return $http.post('backend/config/transaction?agent-id='
                 + encodeURIComponent($scope.agentId), transactionPayload);
           })
           .then(function (transactionResponse) {
             originalTransaction = transactionResponse.data.config;
+            logInfo('POST config/transaction OK');
             return $http.post('backend/config/advanced?agent-rollup-id='
                 + encodeURIComponent($scope.agentRollupId), advancedPayload);
           })
           .then(function (advancedResponse) {
             originalAdvanced = advancedResponse.data;
+            logInfo('POST config/advanced OK');
             $scope.page = pageFromLoaded(originalStorage, originalTransaction, originalAdvanced);
             originalPage = angular.copy($scope.page);
             syncProfileSelect();
+            syncActiveProfile();
+            logInfo('Save complete; active=', $scope.activeProfile);
             deferred.resolve('Saved');
           }, function (response) {
+            logWarn('Save failed (partial apply possible); reloading live config',
+                response && response.status, response && response.data);
             httpErrors.handle(response, deferred);
             // Reload versions / live values after a partial failure
             reloadAll();
@@ -195,6 +250,7 @@ glowroot.controller('ConfigDeploymentProfileCtrl', [
     };
 
     function reloadAll() {
+      logInfo('loading storage + transaction + advanced…');
       $q.all([
         $http.get('backend/admin/storage'),
         $http.get('backend/config/transaction?agent-id=' + encodeURIComponent($scope.agentId)),
@@ -203,6 +259,7 @@ glowroot.controller('ConfigDeploymentProfileCtrl', [
       ]).then(function (responses) {
         onLoaded(responses[0].data, responses[1].data, responses[2].data);
       }, function (response) {
+        logWarn('load failed', response && response.status, response && response.data);
         httpErrors.handle(response);
       });
     }

--- a/ui/app/scripts/controllers/config/deployment-profile.js
+++ b/ui/app/scripts/controllers/config/deployment-profile.js
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* global glowroot, angular */
+
+glowroot.controller('ConfigDeploymentProfileCtrl', [
+  '$scope',
+  '$http',
+  '$q',
+  'confirmIfHasChanges',
+  'httpErrors',
+  'deploymentPresets',
+  function ($scope, $http, $q, confirmIfHasChanges, httpErrors, deploymentPresets) {
+
+    // Embedded-only page (central has different storage model)
+    if ($scope.layout.central) {
+      return;
+    }
+
+    if ($scope.hideMainContent()) {
+      return;
+    }
+
+    $scope.page = {};
+    $scope.profile = 'custom';
+    $scope.loaded = false;
+
+    var originalStorage;
+    var originalTransaction;
+    var originalAdvanced;
+    var originalPage;
+
+    $scope.canEdit = function () {
+      return $scope.layout.adminEdit
+          && $scope.agentRollup.permissions.config.edit.transaction
+          && $scope.agentRollup.permissions.config.edit.advanced;
+    };
+
+    $scope.hasChanges = function () {
+      return originalPage && !angular.equals($scope.page, originalPage);
+    };
+    $scope.$on('$locationChangeStart', confirmIfHasChanges($scope));
+
+    function hoursToDaysList(hoursList) {
+      var days = [];
+      angular.forEach(hoursList, function (hours) {
+        days.push(hours / 24);
+      });
+      return days;
+    }
+
+    function daysToHoursList(daysList) {
+      var hours = [];
+      angular.forEach(daysList, function (days) {
+        hours.push(days * 24);
+      });
+      return hours;
+    }
+
+    function cappedSizesUniform(sizesMb) {
+      if (!sizesMb || !sizesMb.length) {
+        return true;
+      }
+      var first = sizesMb[0];
+      var i;
+      for (i = 1; i < sizesMb.length; i++) {
+        if (sizesMb[i] !== first) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    function pageFromLoaded(storage, transaction, advanced) {
+      var sizesMb = storage.rollupCappedDatabaseSizesMb;
+      return {
+        rollupExpirationDays: hoursToDaysList(storage.rollupExpirationHours),
+        traceExpirationDays: storage.traceExpirationHours / 24,
+        fullQueryTextExpirationDays: storage.fullQueryTextExpirationHours / 24,
+        rollupCappedDatabaseSizeMb: sizesMb && sizesMb.length ? sizesMb[0] : 500,
+        // When per-level sizes differ, force Custom even if the first level matches a preset
+        rollupCappedSizesNonUniform: !cappedSizesUniform(sizesMb),
+        traceCappedDatabaseSizeMb: storage.traceCappedDatabaseSizeMb,
+        slowThresholdMillis: transaction.slowThresholdMillis,
+        profilingIntervalMillis: transaction.profilingIntervalMillis,
+        captureThreadStats: transaction.captureThreadStats,
+        maxTransactionAggregates: advanced.maxTransactionAggregates,
+        maxQueryAggregates: advanced.maxQueryAggregates,
+        maxServiceCallAggregates: advanced.maxServiceCallAggregates,
+        maxTraceEntriesPerTransaction: advanced.maxTraceEntriesPerTransaction,
+        maxProfileSamplesPerTransaction: advanced.maxProfileSamplesPerTransaction
+      };
+    }
+
+    function matchedProfileName() {
+      if ($scope.page.rollupCappedSizesNonUniform) {
+        return 'custom';
+      }
+      return deploymentPresets.matchName($scope.page);
+    }
+
+    function syncProfileSelect() {
+      $scope.profile = matchedProfileName();
+    }
+
+    $scope.onProfileChange = function () {
+      if ($scope.profile === 'custom') {
+        return;
+      }
+      // Populate only — does not persist until Save
+      deploymentPresets.apply($scope.profile, $scope.page);
+      $scope.page.rollupCappedSizesNonUniform = false;
+    };
+
+    $scope.$watch('page', function () {
+      if (!$scope.loaded) {
+        return;
+      }
+      // Keep dropdown in sync when user edits fields manually
+      var matched = matchedProfileName();
+      if ($scope.profile !== matched) {
+        $scope.profile = matched;
+      }
+    }, true);
+
+    function onLoaded(storage, transactionResponse, advanced) {
+      originalStorage = storage;
+      originalTransaction = transactionResponse.config;
+      originalAdvanced = advanced;
+      $scope.page = pageFromLoaded(storage, originalTransaction, advanced);
+      originalPage = angular.copy($scope.page);
+      syncProfileSelect();
+      $scope.loaded = true;
+    }
+
+    $scope.save = function (deferred) {
+      var rollupCapped = $scope.page.rollupCappedDatabaseSizeMb;
+      var storagePayload = {
+        rollupExpirationHours: daysToHoursList($scope.page.rollupExpirationDays),
+        traceExpirationHours: $scope.page.traceExpirationDays * 24,
+        fullQueryTextExpirationHours: $scope.page.fullQueryTextExpirationDays * 24,
+        rollupCappedDatabaseSizesMb: [rollupCapped, rollupCapped, rollupCapped, rollupCapped],
+        traceCappedDatabaseSizeMb: $scope.page.traceCappedDatabaseSizeMb,
+        version: originalStorage.version
+      };
+
+      var transactionPayload = angular.copy(originalTransaction);
+      transactionPayload.slowThresholdMillis = $scope.page.slowThresholdMillis;
+      transactionPayload.profilingIntervalMillis = $scope.page.profilingIntervalMillis;
+      transactionPayload.captureThreadStats = $scope.page.captureThreadStats;
+
+      var advancedPayload = angular.copy(originalAdvanced);
+      advancedPayload.maxTransactionAggregates = $scope.page.maxTransactionAggregates;
+      advancedPayload.maxQueryAggregates = $scope.page.maxQueryAggregates;
+      advancedPayload.maxServiceCallAggregates = $scope.page.maxServiceCallAggregates;
+      advancedPayload.maxTraceEntriesPerTransaction = $scope.page.maxTraceEntriesPerTransaction;
+      advancedPayload.maxProfileSamplesPerTransaction = $scope.page.maxProfileSamplesPerTransaction;
+
+      // Sequential: stop on first failure so we never claim full success after a partial apply
+      $http.post('backend/admin/storage', storagePayload)
+          .then(function (storageResponse) {
+            originalStorage = storageResponse.data;
+            return $http.post('backend/config/transaction?agent-id='
+                + encodeURIComponent($scope.agentId), transactionPayload);
+          })
+          .then(function (transactionResponse) {
+            originalTransaction = transactionResponse.data.config;
+            return $http.post('backend/config/advanced?agent-rollup-id='
+                + encodeURIComponent($scope.agentRollupId), advancedPayload);
+          })
+          .then(function (advancedResponse) {
+            originalAdvanced = advancedResponse.data;
+            $scope.page = pageFromLoaded(originalStorage, originalTransaction, originalAdvanced);
+            originalPage = angular.copy($scope.page);
+            syncProfileSelect();
+            deferred.resolve('Saved');
+          }, function (response) {
+            httpErrors.handle(response, deferred);
+            // Reload versions / live values after a partial failure
+            reloadAll();
+          });
+    };
+
+    function reloadAll() {
+      $q.all([
+        $http.get('backend/admin/storage'),
+        $http.get('backend/config/transaction?agent-id=' + encodeURIComponent($scope.agentId)),
+        $http.get('backend/config/advanced?agent-rollup-id='
+            + encodeURIComponent($scope.agentRollupId))
+      ]).then(function (responses) {
+        onLoaded(responses[0].data, responses[1].data, responses[2].data);
+      }, function (response) {
+        httpErrors.handle(response);
+      });
+    }
+
+    reloadAll();
+  }
+]);

--- a/ui/app/scripts/routes.js
+++ b/ui/app/scripts/routes.js
@@ -560,6 +560,11 @@ glowroot.config([
       templateUrl: 'views/config/advanced.html',
       controller: 'ConfigAdvancedCtrl'
     });
+    $stateProvider.state('config.deploymentProfile', {
+      url: '/deployment-profile',
+      templateUrl: 'views/config/deployment-profile.html',
+      controller: 'ConfigDeploymentProfileCtrl'
+    });
     $stateProvider.state('config.json', {
       url: '/json',
       templateUrl: 'views/config/json.html',

--- a/ui/app/scripts/services/deployment-presets.js
+++ b/ui/app/scripts/services/deployment-presets.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* global glowroot, angular */
+/* global glowroot, angular, console */
 
 // Dev = Glowroot defaults. Prod = leaner retention/capped sizes and lighter profiling for
 // embedded-on-prod (same JVM as the app). Presets only populate the form; Save persists.
@@ -91,6 +91,7 @@ glowroot.factory('deploymentPresets', [
 
     function apply(name, page) {
       var preset = name === 'prod' ? PROD : DEV;
+      console.info('[Glowroot deployment profile] applying preset', name, angular.copy(preset));
       angular.extend(page, copyPreset(preset));
       return page;
     }

--- a/ui/app/scripts/services/deployment-presets.js
+++ b/ui/app/scripts/services/deployment-presets.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* global glowroot, angular */
+
+// Dev = Glowroot defaults. Prod = leaner retention/capped sizes and lighter profiling for
+// embedded-on-prod (same JVM as the app). Presets only populate the form; Save persists.
+glowroot.factory('deploymentPresets', [
+  function () {
+
+    // Matches EmbeddedStorageConfig / TransactionConfig / AdvancedConfig defaults
+    var DEV = {
+      rollupExpirationDays: [3, 14, 90, 90],
+      traceExpirationDays: 14,
+      fullQueryTextExpirationDays: 14,
+      // Applied to all four rollup capped-database levels
+      rollupCappedDatabaseSizeMb: 500,
+      traceCappedDatabaseSizeMb: 500,
+      slowThresholdMillis: 2000,
+      profilingIntervalMillis: 1000,
+      captureThreadStats: true,
+      maxTransactionAggregates: 500,
+      maxQueryAggregates: 500,
+      maxServiceCallAggregates: 500,
+      maxTraceEntriesPerTransaction: 2000,
+      maxProfileSamplesPerTransaction: 50000
+    };
+
+    // Tighter disk/memory and less frequent stack sampling for shared-JVM embedded deploys
+    var PROD = {
+      rollupExpirationDays: [1, 7, 30, 30],
+      traceExpirationDays: 7,
+      fullQueryTextExpirationDays: 7,
+      rollupCappedDatabaseSizeMb: 100,
+      traceCappedDatabaseSizeMb: 100,
+      slowThresholdMillis: 2000,
+      profilingIntervalMillis: 5000,
+      captureThreadStats: false,
+      maxTransactionAggregates: 200,
+      maxQueryAggregates: 200,
+      maxServiceCallAggregates: 200,
+      maxTraceEntriesPerTransaction: 500,
+      maxProfileSamplesPerTransaction: 10000
+    };
+
+    function copyPreset(preset) {
+      return angular.copy(preset);
+    }
+
+    function matches(page, preset) {
+      if (!page || !preset) {
+        return false;
+      }
+      return angular.equals(page.rollupExpirationDays, preset.rollupExpirationDays)
+          && page.traceExpirationDays === preset.traceExpirationDays
+          && page.fullQueryTextExpirationDays === preset.fullQueryTextExpirationDays
+          && page.rollupCappedDatabaseSizeMb === preset.rollupCappedDatabaseSizeMb
+          && page.traceCappedDatabaseSizeMb === preset.traceCappedDatabaseSizeMb
+          && page.slowThresholdMillis === preset.slowThresholdMillis
+          && page.profilingIntervalMillis === preset.profilingIntervalMillis
+          && page.captureThreadStats === preset.captureThreadStats
+          && page.maxTransactionAggregates === preset.maxTransactionAggregates
+          && page.maxQueryAggregates === preset.maxQueryAggregates
+          && page.maxServiceCallAggregates === preset.maxServiceCallAggregates
+          && page.maxTraceEntriesPerTransaction === preset.maxTraceEntriesPerTransaction
+          && page.maxProfileSamplesPerTransaction === preset.maxProfileSamplesPerTransaction;
+    }
+
+    function matchName(page) {
+      if (matches(page, DEV)) {
+        return 'dev';
+      }
+      if (matches(page, PROD)) {
+        return 'prod';
+      }
+      return 'custom';
+    }
+
+    function apply(name, page) {
+      var preset = name === 'prod' ? PROD : DEV;
+      angular.extend(page, copyPreset(preset));
+      return page;
+    }
+
+    return {
+      DEV: DEV,
+      PROD: PROD,
+      copyPreset: copyPreset,
+      matches: matches,
+      matchName: matchName,
+      apply: apply
+    };
+  }
+]);

--- a/ui/app/views/config.html
+++ b/ui/app/views/config.html
@@ -176,6 +176,12 @@
            gt-url="config/advanced{{agentQueryString()}}"
            gt-active="currentUrl() === 'config/advanced'">
       </div>
+      <div gt-sidebar-item
+           gt-display="Deployment profile"
+           gt-url="config/deployment-profile{{agentQueryString()}}"
+           gt-active="currentUrl() === 'config/deployment-profile'"
+           ng-if="!layout.central">
+      </div>
     </div>
   </div>
   <div class="card mt-4"

--- a/ui/app/views/config/deployment-profile.html
+++ b/ui/app/views/config/deployment-profile.html
@@ -45,6 +45,11 @@
               <option value="prod">Prod</option>
               <option value="custom">Custom</option>
             </select>
+            <span class="help-block d-inline-block ml-3 mb-0"
+                  ng-if="loaded">
+              Active: <strong>{{ profileDisplayName(activeProfile) }}</strong>
+              <span ng-if="hasChanges()"> — preview not saved</span>
+            </span>
           </div>
         </div>
 

--- a/ui/app/views/config/deployment-profile.html
+++ b/ui/app/views/config/deployment-profile.html
@@ -1,0 +1,239 @@
+<!--
+  Copyright 2026 the original author or authors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<div class="card">
+  <div class="card-header">
+    <h2>Deployment profile</h2>
+  </div>
+  <div class="card-body">
+    <div ng-hide="hideMainContent()">
+      <div ng-include src="'template/gt-loading-overlay.html'"></div>
+      <div ng-include src="'template/gt-http-error-overlay.html'"></div>
+      <form name="formCtrl"
+            style="padding-top: 15px;"
+            novalidate>
+        <div class="help-block" style="margin-bottom: 1.25rem;">
+          Selecting a profile fills the values below. Click <strong>Save changes</strong> to apply.
+          Nothing is written until you save (safe if something goes wrong mid-edit).
+          <em>Dev</em> matches Glowroot defaults; <em>Prod</em> uses leaner storage and lighter
+          profiling for embedded agents that share the application JVM.
+        </div>
+
+        <div class="form-group row">
+          <label class="col-xl-3 gt-form-label-xl" for="deploymentProfileSelect">Profile</label>
+          <div class="col-xl-9">
+            <select id="deploymentProfileSelect"
+                    class="custom-select"
+                    style="max-width: 12rem;"
+                    ng-model="profile"
+                    ng-change="onProfileChange()"
+                    ng-disabled="!canEdit() || !loaded"
+                    aria-label="Deployment profile">
+              <option value="dev">Dev</option>
+              <option value="prod">Prod</option>
+              <option value="custom">Custom</option>
+            </select>
+          </div>
+        </div>
+
+        <fieldset class="gt-fieldset">
+          <legend class="gt-legend">Storage</legend>
+          <div class="gt-fieldset-under-normal-form">
+            <div gt-form-group
+                 gt-label="1 minute aggregates retention"
+                 gt-model="page.rollupExpirationDays[0]"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em"
+                 gt-addon="days">
+            </div>
+            <div gt-form-group
+                 gt-label="5 minute aggregates retention"
+                 gt-model="page.rollupExpirationDays[1]"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em"
+                 gt-addon="days">
+            </div>
+            <div gt-form-group
+                 gt-label="30 minute aggregates retention"
+                 gt-model="page.rollupExpirationDays[2]"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em"
+                 gt-addon="days">
+            </div>
+            <div gt-form-group
+                 gt-label="4 hour aggregates retention"
+                 gt-model="page.rollupExpirationDays[3]"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em"
+                 gt-addon="days">
+            </div>
+            <div gt-form-group
+                 gt-label="Trace data retention"
+                 gt-model="page.traceExpirationDays"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em"
+                 gt-addon="days">
+            </div>
+            <div gt-form-group
+                 gt-label="Full query text retention"
+                 gt-model="page.fullQueryTextExpirationDays"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em"
+                 gt-addon="days">
+            </div>
+            <div gt-form-group
+                 gt-label="Rollup capped database size (all levels)"
+                 gt-model="page.rollupCappedDatabaseSizeMb"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em"
+                 gt-addon="MB">
+              <div class="help-block">
+                Applied to all four rollup capped-database sizes on save.
+                For different per-level sizes use Administration → Storage.
+              </div>
+            </div>
+            <div gt-form-group
+                 gt-label="Trace capped database size"
+                 gt-model="page.traceCappedDatabaseSizeMb"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em"
+                 gt-addon="MB">
+            </div>
+          </div>
+        </fieldset>
+
+        <fieldset class="gt-fieldset">
+          <legend class="gt-legend">Transactions / profiling</legend>
+          <div class="gt-fieldset-under-normal-form">
+            <div gt-form-group
+                 gt-label="Slow threshold"
+                 gt-model="page.slowThresholdMillis"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em"
+                 gt-addon="milliseconds">
+            </div>
+            <div gt-form-group
+                 gt-label="Profiling interval"
+                 gt-model="page.profilingIntervalMillis"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em"
+                 gt-addon="milliseconds">
+            </div>
+            <div gt-form-group
+                 gt-type="checkbox"
+                 gt-label="Thread stats"
+                 gt-checkbox-label="Capture JVM thread stats"
+                 gt-model="page.captureThreadStats"
+                 gt-disabled="!canEdit()">
+            </div>
+          </div>
+        </fieldset>
+
+        <fieldset class="gt-fieldset">
+          <legend class="gt-legend">Advanced limits</legend>
+          <div class="gt-fieldset-under-normal-form">
+            <div gt-form-group
+                 gt-label="Max transaction aggregates"
+                 gt-model="page.maxTransactionAggregates"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em">
+            </div>
+            <div gt-form-group
+                 gt-label="Max query aggregates"
+                 gt-model="page.maxQueryAggregates"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em">
+            </div>
+            <div gt-form-group
+                 gt-label="Max service call aggregates"
+                 gt-model="page.maxServiceCallAggregates"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em">
+            </div>
+            <div gt-form-group
+                 gt-label="Max trace entries per transaction"
+                 gt-model="page.maxTraceEntriesPerTransaction"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em">
+            </div>
+            <div gt-form-group
+                 gt-label="Max profile samples per transaction"
+                 gt-model="page.maxProfileSamplesPerTransaction"
+                 gt-number="true"
+                 gt-pattern="pattern.integer"
+                 gt-required="loaded"
+                 gt-disabled="!canEdit()"
+                 gt-width="7em">
+            </div>
+          </div>
+        </fieldset>
+
+        <div class="form-group row"
+             ng-if="canEdit()">
+          <div class="offset-xl-3 col-xl-9">
+            <div gt-button
+                 gt-label="Save changes"
+                 gt-click="save(deferred)"
+                 gt-validate-form="formCtrl">
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+<div ng-include="'template/gt-confirmation.html'"></div>


### PR DESCRIPTION
**Apply lean defaults** on Administration → Storage (Maintenance on embedded; small Lean defaults block on Central).

Fills the Storage form only — nothing hits disk until **Save** (same single dmin/storage POST as today). Help is in the section **?** icon, like the other Maintenance groups.

**Sets**
- Embedded: shorter retention + smaller capped DB sizes
- Central: shorter Cassandra TTLs (rollup / query / profile / traces)

**Not in this PR**
- No new config page
- No multi-POST across Transactions/Advanced
- Does not answer Central capacity sizing (#715)

**Why**
A lot of embedded pain is leaving full default retention/capped sizes on a shared JVM until H2 hurts. One button on the existing Storage page is enough.

**Test**
- [x] Embedded: Maintenance → Apply lean defaults → form fills → Save
- [ ] Central: Lean defaults → Apply lean defaults → TTL fields fill → Save