### PR TITLE
Align embedded Jackson max nesting depth with central (#1122)

### DIFF
--- a/agent/embedded/src/main/java/org/glowroot/agent/embedded/init/EmbeddedGlowrootAgentInit.java
+++ b/agent/embedded/src/main/java/org/glowroot/agent/embedded/init/EmbeddedGlowrootAgentInit.java
@@ -22,6 +22,8 @@ import java.lang.instrument.Instrumentation;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.StreamWriteConstraints;
+import com.google.common.base.Strings;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
@@ -66,6 +68,11 @@ class EmbeddedGlowrootAgentInit implements GlowrootAgentInit {
         this.agentDirLockCloseable = agentDirLockCloseable;
         final boolean configReadOnly =
                 Boolean.parseBoolean(properties.get("glowroot.config.readOnly"));
+        // Same as central (#1122 / PR #1160): deep profile JSON can exceed Jackson's default
+        // max nesting depth (1000). Override early, before UI serializes profiles.
+        // glowroot.properties: jackson.max.nesting.depth=<n>
+        // or JVM: -Dglowroot.jackson.max.nesting.depth=<n>
+        applyJacksonStreamWriteConstraints(properties);
         embeddedAgentModule = new EmbeddedAgentModule(pluginsDir, confDirs, configReadOnly, logDir,
                 tmpDir, instrumentation, preCheckClassFileTransformer, glowrootJarFile,
                 glowrootVersion, offlineViewer);
@@ -135,4 +142,14 @@ class EmbeddedGlowrootAgentInit implements GlowrootAgentInit {
     @Override
     @OnlyUsedByTests
     public void awaitClose() {}
+
+    private static void applyJacksonStreamWriteConstraints(Map<String, String> properties) {
+        int maxNestingDepth = 1000;
+        String jacksonMaxNestingDepth = properties.get("glowroot.jackson.max.nesting.depth");
+        if (!Strings.isNullOrEmpty(jacksonMaxNestingDepth)) {
+            maxNestingDepth = Integer.parseInt(jacksonMaxNestingDepth);
+        }
+        StreamWriteConstraints.overrideDefaultStreamWriteConstraints(StreamWriteConstraints
+                .builder().maxNestingDepth(maxNestingDepth).build());
+    }
 }


### PR DESCRIPTION
## Summary
- Mirrors central #1160 for **embedded**: apply `StreamWriteConstraints` max nesting depth at agent startup
- Configurable via `jackson.max.nesting.depth` in `glowroot.properties` (or `-Dglowroot.jackson.max.nesting.depth`)
- Default remains 1000 (Jackson default) until configured — same as central
- Fixes the embedded gap for deep trace Profile UI / export (`StreamConstraintsException`)

Closes / related: #1122 (canonical). #1141 is a duplicate of #1122.

## Test plan
- [ ] Embedded: with default config, agent starts normally
- [ ] Set `jackson.max.nesting.depth=10000` in `glowroot.properties`, restart, open a deep profile / export — no `StreamConstraintsException`
- [ ] Central path unchanged (still uses `glowroot-central.properties` from #1160)
