### PR TITLE
[BUGFIX] Log embedded UI init timing (clarify missing listen message)

### DIFF
--- a/agent/embedded/src/main/java/org/glowroot/agent/embedded/init/EmbeddedAgentModule.java
+++ b/agent/embedded/src/main/java/org/glowroot/agent/embedded/init/EmbeddedAgentModule.java
@@ -223,7 +223,9 @@ class EmbeddedAgentModule {
 
     void initEmbeddedServer() throws Exception {
         if (simpleRepoModule == null) {
-            // repo module failed to start
+            // repo module failed to start (error already logged from Init-Repo)
+            startupLogger.error("embedded UI will not start because storage failed to initialize"
+                    + " (see earlier \"Glowroot cannot start\" error)");
             return;
         }
         if (agentModule != null) {

--- a/agent/embedded/src/main/java/org/glowroot/agent/embedded/init/EmbeddedGlowrootAgentInit.java
+++ b/agent/embedded/src/main/java/org/glowroot/agent/embedded/init/EmbeddedGlowrootAgentInit.java
@@ -41,7 +41,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 class EmbeddedGlowrootAgentInit implements GlowrootAgentInit {
 
-    private static final Logger logger = LoggerFactory.getLogger(EmbeddedGlowrootAgentInit.class);
+    // same logger name as version / "UI listening" lines (visible in console + glowroot log)
+    private static final Logger startupLogger = LoggerFactory.getLogger("org.glowroot");
 
     private final File dataDir;
     private final boolean offlineViewer;
@@ -85,7 +86,10 @@ class EmbeddedGlowrootAgentInit implements GlowrootAgentInit {
                 embeddedAgentModule.onEnteringMain(confDirs, configReadOnly, dataDir,
                         glowrootJarFile, properties, instrumentation, collectorProxyClass,
                         glowrootVersion, mainClass);
-                // starting new thread in order not to block startup
+                // starting new thread in order not to block application startup; daemon so the
+                // JVM can still exit if main fails quickly (see #1002)
+                startupLogger.info("initializing embedded UI (asynchronous;"
+                        + " \"UI listening\" follows when bind succeeds)");
                 Thread thread = new Thread(new Runnable() {
                     @Override
                     public void run() {
@@ -96,7 +100,8 @@ class EmbeddedGlowrootAgentInit implements GlowrootAgentInit {
                             embeddedAgentModule.waitForSimpleRepoModule();
                             embeddedAgentModule.initEmbeddedServer();
                         } catch (Exception e) {
-                            logger.error(e.getMessage(), e);
+                            startupLogger.error("embedded UI failed to start: {}", e.getMessage(),
+                                    e);
                         }
                     }
                 });
@@ -109,6 +114,8 @@ class EmbeddedGlowrootAgentInit implements GlowrootAgentInit {
             // this is for offline viewer and for tests
             onEnteringMain.run(null);
         } else {
+            // UI bind is deferred until application main (not during premain)
+            startupLogger.info("embedded UI will start after application main is entered");
             embeddedAgentModule.setOnEnteringMain(onEnteringMain);
         }
     }


### PR DESCRIPTION
## Summary
- Clarifies that the embedded UI starts **after application `main`** and binds on a **daemon** background thread (so a JVM that exits quickly never prints `UI listening`).
- Logs those steps on `org.glowroot` (same channel as version / listen lines).
- Emits an explicit error when storage init failed and UI start was previously skipped silently.

Related: #1002 (support comment already posted; this is observability only, not a behavior change).

## Test plan
- [x] `mvn clean install -pl :glowroot-agent-ui-sandbox -am -DskipTests` (install after killing leftover sandbox lock)
- [x] Start UiSandbox with `-Dglowroot.sandbox.javaagent=true` and confirm console shows, in order:
  - `embedded UI will start after application main is entered`
  - `initializing embedded UI (asynchronous; …)`
  - `UI listening on 127.0.0.1:4000`
- [ ] (Optional) Force a bad/corrupt data dir or storage failure and confirm `embedded UI will not start because storage failed to initialize`