### PR TITLE
[BUGFIX] Honor browser 24-hour clock preference in the UI

### DIFF
--- a/ui/app/scripts/app.js
+++ b/ui/app/scripts/app.js
@@ -26,6 +26,29 @@ var glowroot = angular.module('glowroot', [
 
 var Glowroot;
 
+// Moment ships with English only (no locale packs). LT/LTS would always be 12-hour AM/PM.
+// Honor the browser/OS hour cycle so header range + custom pickers use 24h where expected (#1108).
+var gtDateTimeWithMillisFormat;
+var gtTimeOfDayWithMillisFormat;
+(function () {
+  var hour12 = true;
+  try {
+    hour12 = new Intl.DateTimeFormat(undefined, {hour: 'numeric'}).resolvedOptions().hour12 !== false;
+  } catch (ignored) {
+    // keep English 12-hour default
+  }
+  if (!hour12) {
+    moment.updateLocale('en', {
+      longDateFormat: {
+        LT: 'HH:mm',
+        LTS: 'HH:mm:ss'
+      }
+    });
+  }
+  gtDateTimeWithMillisFormat = hour12 ? 'YYYY-MM-DD h:mm:ss.SSS a (Z)' : 'YYYY-MM-DD HH:mm:ss.SSS (Z)';
+  gtTimeOfDayWithMillisFormat = hour12 ? 'h:mm:ss.SSS a (Z)' : 'HH:mm:ss.SSS (Z)';
+})();
+
 glowroot.config([
   '$locationProvider',
   '$httpProvider',

--- a/ui/app/scripts/controllers/jvm/gauge-values.js
+++ b/ui/app/scripts/controllers/jvm/gauge-values.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* global glowroot, angular, $, moment */
+/* global glowroot, angular, $, moment, gtTimeOfDayWithMillisFormat */
 
 glowroot.controller('JvmGaugeValuesCtrl', [
   '$scope',
@@ -507,7 +507,7 @@ glowroot.controller('JvmGaugeValuesCtrl', [
             var tooltip = '<table class="gt-chart-tooltip">';
             tooltip += '<tr><td colspan="2" style="font-weight: 600;">' + shortDisplayMap[label];
             tooltip += '</td></tr><tr><td style="padding-right: 10px;">Time:</td><td style="font-weight: 400;">';
-            tooltip += moment(xval).format('h:mm:ss.SSS a (Z)') + '</td></tr>';
+            tooltip += moment(xval).format(gtTimeOfDayWithMillisFormat) + '</td></tr>';
             tooltip += '<tr><td style="padding-right: 10px;">Value:</td><td style="font-weight: 600;">';
             tooltip += $filter('gtGaugeValue')(nonScaledValue) + gaugeUnits[label] + '</td></tr>';
             tooltip += '</table>';

--- a/ui/app/scripts/controllers/synthetic-monitors.js
+++ b/ui/app/scripts/controllers/synthetic-monitors.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* global glowroot, angular, $, moment */
+/* global glowroot, angular, $, moment, gtTimeOfDayWithMillisFormat */
 
 glowroot.controller('SyntheticMonitorsCtrl', [
   '$scope',
@@ -261,7 +261,7 @@ glowroot.controller('SyntheticMonitorsCtrl', [
             var tooltip = '<table class="gt-chart-tooltip">';
             tooltip += '<tr><td colspan="2" style="font-weight: 600;">' + displayMap[label];
             tooltip += '</td></tr><tr><td style="padding-right: 10px;">Time:</td><td style="font-weight: 400;">';
-            tooltip += moment(xval).format('h:mm:ss.SSS a (Z)') + '</td></tr>';
+            tooltip += moment(xval).format(gtTimeOfDayWithMillisFormat) + '</td></tr>';
             tooltip += '<tr><td style="padding-right: 10px;">Value:</td><td style="font-weight: 600;">';
             tooltip += $filter('gtMillis')(yval) + ' milliseconds</td></tr>';
             tooltip += '</table>';

--- a/ui/app/scripts/handlebars-rendering.js
+++ b/ui/app/scripts/handlebars-rendering.js
@@ -20,7 +20,7 @@
 
 // Glowroot dependency is used for spinner, but is not used in export file
 // angular dependency is used to call login.goToLogin() on 401 responses, but is not used in export file
-/* global $, Handlebars, JST, moment, Glowroot, angular, SqlPrettyPrinter, gtClipboard, gtParseIncludesExcludes, console */
+/* global $, Handlebars, JST, moment, Glowroot, angular, SqlPrettyPrinter, gtClipboard, gtParseIncludesExcludes, console, gtDateTimeWithMillisFormat */
 
 // IMPORTANT: DO NOT USE ANGULAR IN THIS FILE
 // that would require adding angular to trace-export.js
@@ -271,7 +271,7 @@ HandlebarsRendering = (function () {
   });
 
   Handlebars.registerHelper('date', function (timestamp) {
-    return moment(timestamp).format('YYYY-MM-DD h:mm:ss.SSS a (Z)');
+    return moment(timestamp).format(gtDateTimeWithMillisFormat);
   });
 
   Handlebars.registerHelper('nanosToMillis', function (nanos) {


### PR DESCRIPTION
## Summary
- Detect the browser/OS hour cycle via `Intl.DateTimeFormat(...).hour12` and, when 24-hour is preferred, override moment English `LT`/`LTS` to `HH:mm` / `HH:mm:ss`.
- Align remaining hard-coded `h:mm… a` timestamp formats (trace export helper, gauge/synthetic tooltips) with the same preference.
- Fixes the header time range and custom-range pickers showing AM/PM for users on 24-hour locales (#1108). Embedded and central share this UI code.

## Test plan
- [x] Build UI assets (do **not** use `-Dglowroot.ui.skip`): `mvn clean install -pl :glowroot-agent-ui-sandbox -am -DskipTests`
- [x] Start sandbox and open http://127.0.0.1:4000
- [x] With OS/browser set to **24-hour** (e.g. Italian Windows): header custom/absolute range shows `HH:mm` (no AM/PM); Custom range From/To time pickers likewise
- [ ] With OS/browser set to **12-hour** (e.g. en-US): header and pickers still show AM/PM as before
- [x] Spot-check a gauge chart tooltip and a trace detail timestamp for matching clock style
- [ ] Wait for maintainer/user manual OK before marking ready

Closes #1108