### PR TITLE
[BUGFIX] Health check, filtered slow-trace counts, and JUL formatMessage NPE

### DIFF
--- a/agent/plugins/logger-plugin/src/main/java/org/glowroot/agent/plugin/logger/JavaLoggingAspect.java
+++ b/agent/plugins/logger-plugin/src/main/java/org/glowroot/agent/plugin/logger/JavaLoggingAspect.java
@@ -89,7 +89,14 @@ public class JavaLoggingAspect {
             // cannot check Logger.getFilter().isLoggable(LogRecord) because the Filter object
             // could be stateful and might alter its state (e.g.
             // com.sun.mail.util.logging.DurationFilter)
-            String formattedMessage = nullToEmpty(formatter.formatMessage(record));
+            String formattedMessage;
+            try {
+                formattedMessage = nullToEmpty(formatter.formatMessage(record));
+            } catch (RuntimeException e) {
+                // PropertyResourceBundle / MessageFormat can NPE with null params or custom
+                // ResourceBundle loaders (e.g. WebSphere) — see #706
+                formattedMessage = nullToEmpty(record.getMessage());
+            }
             int lvl = level.intValue();
             Throwable t = record.getThrown();
             if (LoggerPlugin.markTraceAsError(lvl >= Level.SEVERE.intValue(),

--- a/agent/plugins/logger-plugin/src/test/java/org/glowroot/agent/plugin/logger/JavaLoggingIT.java
+++ b/agent/plugins/logger-plugin/src/test/java/org/glowroot/agent/plugin/logger/JavaLoggingIT.java
@@ -17,6 +17,7 @@ package org.glowroot.agent.plugin.logger;
 
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -228,6 +229,19 @@ public class JavaLoggingIT {
         assertThat(entry.getDepth()).isEqualTo(0);
         assertThat(entry.getMessage()).isEqualTo("log severe: null - efg__");
 
+        assertThat(i.hasNext()).isFalse();
+    }
+
+    @Test
+    public void testLogWithNullMessageAndResourceBundle() throws Exception {
+        // Formatter.formatMessage NPEs when the message key is null and a ResourceBundle is set
+        // (PropertyResourceBundle.handleGetObject) — see #706
+        Trace trace = container.execute(ShouldLogWithNullMessageAndResourceBundle.class);
+
+        Iterator<Trace.Entry> i = trace.getEntryList().iterator();
+        Trace.Entry entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage()).startsWith("log warning:");
         assertThat(i.hasNext()).isFalse();
     }
 
@@ -604,6 +618,26 @@ public class JavaLoggingIT {
             lr.setLoggerName(logger.getName()); // test logger name
             logger.log(lr);
             logger.log(new LogRecord(Level.SEVERE, "efg__"));
+        }
+    }
+
+    public static class ShouldLogWithNullMessageAndResourceBundle
+            implements AppUnderTest, TransactionMarker {
+        private static final Logger logger = Logger.getLogger(
+                ShouldLogWithNullMessageAndResourceBundle.class.getName(), "julmsgs");
+
+        @Override
+        public void executeApp() {
+            transactionMarker();
+        }
+
+        @Override
+        public void transactionMarker() {
+            LogRecord lr = new LogRecord(Level.WARNING, null);
+            lr.setLoggerName(logger.getName());
+            lr.setResourceBundleName("julmsgs");
+            lr.setResourceBundle(ResourceBundle.getBundle("julmsgs"));
+            logger.log(lr);
         }
     }
 }

--- a/central/src/main/java/org/glowroot/central/repo/RepoAdminImpl.java
+++ b/central/src/main/java/org/glowroot/central/repo/RepoAdminImpl.java
@@ -57,8 +57,14 @@ public class RepoAdminImpl implements RepoAdmin {
 
     @Override
     public void runHealthCheck() throws Exception {
+        // Cheap Cassandra liveness probe (fails when ControlConnection / all nodes are down).
+        session.read("select release_version from system.local where key = 'local'",
+                CassandraProfile.web);
         long now = clock.currentTimeMillis();
-        activeAgentDao.readActiveTopLevelAgentRollups(now - HOURS.toMillis(4), now, CassandraProfile.web);
+        // Must wait: previously the CompletionStage was ignored, so /health always returned 200
+        // even when Cassandra was unreachable (see github.com/glowroot/glowroot/issues/766).
+        activeAgentDao.readActiveTopLevelAgentRollups(now - HOURS.toMillis(4), now, CassandraProfile.web)
+                .toCompletableFuture().get();
     }
 
     @Override

--- a/ui/app/scripts/controllers/transaction/tabs.js
+++ b/ui/app/scripts/controllers/transaction/tabs.js
@@ -28,6 +28,7 @@ glowroot.controller('TransactionTabCtrl', [
   function ($scope, $location, $http, $timeout, $filter, queryStrings, httpErrors, shortName) {
 
     var concurrentUpdateCount = 0;
+    var traceCountFromChart = false;
 
     // using $watch instead of $watchGroup because $watchGroup has confusing behavior regarding oldValues
     // (see https://github.com/angular/angular.js/pull/12643)
@@ -80,13 +81,20 @@ glowroot.controller('TransactionTabCtrl', [
 
     var initialStateChangeSuccess = true;
     $scope.$on('gtStateChangeSuccess', function () {
-      if ($scope.range.last && !initialStateChangeSuccess) {
+      if (!initialStateChangeSuccess) {
         $timeout(function () {
           // slight delay to de-prioritize summaries data request
+          // Always refresh: filter-only URL changes must update the tab count (#725)
           updateTabBarData();
         }, 100);
       }
       initialStateChangeSuccess = false;
+    });
+
+    // Chart points are the source of truth when under the result limit
+    $scope.$on('gtDisplayedTraceCount', function (event, count) {
+      traceCountFromChart = true;
+      $scope.traceCount = count;
     });
 
     function updateTabBarData(autoRefresh) {
@@ -97,6 +105,8 @@ glowroot.controller('TransactionTabCtrl', [
         $scope.traceCount = 0;
         return;
       }
+      traceCountFromChart = false;
+      var search = $location.search();
       var query = {
         agentRollupId: $scope.agentRollupId,
         transactionType: $scope.transactionType,
@@ -104,6 +114,31 @@ glowroot.controller('TransactionTabCtrl', [
         from: $scope.range.chartFrom,
         to: $scope.range.chartTo
       };
+      // Forward Slow/Error Traces filters so the tab count matches filtered points (#725).
+      // Location uses custom-attribute-* for bookmarks; the API expects attribute-* (see points query).
+      [
+        'duration-millis-low',
+        'duration-millis-high',
+        'headline-comparator',
+        'headline',
+        'error-message-comparator',
+        'error-message',
+        'user-comparator',
+        'user'
+      ].forEach(function (key) {
+        if (search[key]) {
+          query[key] = search[key];
+        }
+      });
+      if (search['custom-attribute-name']) {
+        query.attributeName = search['custom-attribute-name'];
+      }
+      if (search['custom-attribute-value-comparator']) {
+        query.attributeValueComparator = search['custom-attribute-value-comparator'];
+      }
+      if (search['custom-attribute-value']) {
+        query.attributeValue = search['custom-attribute-value'];
+      }
       if (autoRefresh) {
         query.autoRefresh = true;
       }
@@ -112,6 +147,10 @@ glowroot.controller('TransactionTabCtrl', [
           .then(function (response) {
             concurrentUpdateCount--;
             if (concurrentUpdateCount) {
+              return;
+            }
+            // Chart emit wins when under limit (avoids stale/unfiltered race with this request)
+            if (traceCountFromChart) {
               return;
             }
             $scope.traceCount = response.data;

--- a/ui/app/scripts/controllers/transaction/traces.js
+++ b/ui/app/scripts/controllers/transaction/traces.js
@@ -18,6 +18,7 @@
 
 glowroot.controller('TracesCtrl', [
   '$scope',
+  '$rootScope',
   '$location',
   '$http',
   '$q',
@@ -27,7 +28,7 @@ glowroot.controller('TracesCtrl', [
   'traceModal',
   'queryStrings',
   'traceKind',
-  function ($scope, $location, $http, $q, locationChanges, charts, httpErrors, traceModal, queryStrings, traceKind) {
+  function ($scope, $rootScope, $location, $http, $q, locationChanges, charts, httpErrors, traceModal, queryStrings, traceKind) {
 
     $scope.$parent.activeTabItem = 'traces';
 
@@ -154,6 +155,12 @@ glowroot.controller('TracesCtrl', [
             $scope.showExpiredMessage = data.expired;
             $scope.chartLimitExceeded = data.limitExceeded;
             $scope.chartLimit = limit;
+            // Keep Slow/Error traces tab count in sync with what the chart actually shows (#725).
+            // When the limit is exceeded the tab controller still fetches the filtered total.
+            if (!data.limitExceeded) {
+              // ui-router named views are siblings — $rootScope reaches the tab controller
+              $rootScope.$broadcast('gtDisplayedTraceCount', traceCount);
+            }
             // user clicked on Refresh button, need to reset axes
             plot.getAxes().xaxis.options.min = from;
             plot.getAxes().xaxis.options.max = to;
@@ -183,6 +190,8 @@ glowroot.controller('TracesCtrl', [
       }
       charts.applyLast($scope);
       angular.extend(appliedFilter, $scope.filter);
+      // Write filters to the URL before chartRefresh so the tab count request sees them (#725)
+      updateLocation();
       $scope.range.chartRefresh++;
     };
 

--- a/ui/app/styles/common.scss
+++ b/ui/app/styles/common.scss
@@ -107,6 +107,11 @@
   margin-bottom: .5rem;
 }
 
+// Bootstrap popovers default to max-width ~276px; filter help needs to match its content width
+.popover.gt-traces-filters-popover {
+  max-width: none;
+}
+
 .gt-button-message {
   display: inline-block;
   font-size: 1rem;

--- a/ui/app/template/help/traces-filters.html
+++ b/ui/app/template/help/traces-filters.html
@@ -1,0 +1,27 @@
+<div style="margin: 10px; width: 36em; max-width: 90vw; box-sizing: border-box; word-wrap: break-word; overflow-wrap: break-word; text-align: left;">
+  <div><strong>How Slow / Error trace filters work</strong></div>
+  <p style="margin: 6px 0 8px;">
+    Filters apply only after <em>Refresh</em>. They narrow traces on this chart and the tab count;
+    they do <em>not</em> change average / percentiles / throughput.
+  </p>
+  <div style="display: flex; flex-wrap: wrap; gap: 0 1.5em;">
+    <ul style="margin: 0; padding-left: 1.2em; flex: 1 1 15em; box-sizing: border-box;">
+      <li><strong>Response time</strong> — duration (ms): greater / less / between.</li>
+      <li><strong>Headline/URL</strong> — stored headline (often URL or txn text).
+        Comparators: begins, equals, ends, contains, does not contain.
+        Not full query-string search unless it is in the headline.</li>
+      <li ng-if="showErrorMessageFilter"><strong>Error message</strong> — error text
+        (same comparators as Headline/URL).</li>
+    </ul>
+    <ul style="margin: 0; padding-left: 1.2em; flex: 1 1 15em; box-sizing: border-box;">
+      <li><strong>User</strong> — user on the trace (servlet plugin user attribute).</li>
+      <li><strong>Attribute name / value</strong> — custom / session attributes.
+        Dropdown only if names exist for this transaction type.</li>
+      <li><strong>Result limit</strong> — max chart points (slowest matches).
+        Over limit → warning; tab count still shows matching total.</li>
+    </ul>
+  </div>
+  <p style="margin: 8px 0 0;">
+    <em>Clear criteria</em> resets all filters and refreshes.
+  </p>
+</div>

--- a/ui/app/views/transaction/traces.html
+++ b/ui/app/views/transaction/traces.html
@@ -253,6 +253,19 @@
                 ng-click="clearCriteria()">
           Clear criteria
         </button>
+        <button type="button"
+                class="btn btn-link gt-button-spacing p-0 align-baseline"
+                uib-popover-template="'template/help/traces-filters.html'"
+                popover-class="gt-traces-filters-popover"
+                popover-placement="top"
+                popover-trigger="'outsideClick'"
+                style="line-height: 1; vertical-align: middle;"
+                title="Filter help"
+                aria-label="Filter help">
+          <span class="fas fa-info-circle"
+                style="font-size: 1.25rem;">
+          </span>
+        </button>
       </div>
     </div>
   </div>

--- a/ui/src/main/java/org/glowroot/ui/HealthCheckHttpService.java
+++ b/ui/src/main/java/org/glowroot/ui/HealthCheckHttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,22 @@
  */
 package org.glowroot.ui;
 
+import com.google.common.base.Throwables;
+import com.google.common.net.MediaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.glowroot.common2.repo.RepoAdmin;
 import org.glowroot.ui.CommonHandler.CommonRequest;
 import org.glowroot.ui.CommonHandler.CommonResponse;
 import org.glowroot.ui.HttpSessionManager.Authentication;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
 
 class HealthCheckHttpService implements HttpService {
+
+    private static final Logger logger = LoggerFactory.getLogger(HealthCheckHttpService.class);
 
     private final RepoAdmin repoAdmin;
 
@@ -38,7 +46,15 @@ class HealthCheckHttpService implements HttpService {
     @Override
     public CommonResponse handleRequest(CommonRequest request, Authentication authentication)
             throws Exception {
-        repoAdmin.runHealthCheck();
-        return new CommonResponse(OK);
+        try {
+            repoAdmin.runHealthCheck();
+            return new CommonResponse(OK, MediaType.PLAIN_TEXT_UTF_8, "Glowroot OK\n");
+        } catch (Exception e) {
+            // Avoid a blank browser page: return a clear text body and log for operators (#766)
+            Throwable root = Throwables.getRootCause(e);
+            logger.error("Health check failed: {}", root.toString(), e);
+            return new CommonResponse(SERVICE_UNAVAILABLE, MediaType.PLAIN_TEXT_UTF_8,
+                    "Glowroot health check failed: " + root.toString() + "\n");
+        }
     }
 }

--- a/ui/src/main/java/org/glowroot/ui/TracePointJsonService.java
+++ b/ui/src/main/java/org/glowroot/ui/TracePointJsonService.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.base.Strings;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -40,7 +41,6 @@ import org.glowroot.common2.repo.ConfigRepository;
 import org.glowroot.common2.repo.ImmutableTraceQuery;
 import org.glowroot.common2.repo.TraceRepository;
 import org.glowroot.common2.repo.TraceRepository.TraceQuery;
-import org.glowroot.ui.TransactionJsonService.TransactionDataRequest;
 
 import static java.util.concurrent.TimeUnit.HOURS;
 
@@ -69,26 +69,14 @@ class TracePointJsonService {
 
     @GET(path = "/backend/transaction/trace-count", permission = "agent:transaction:traces")
     String getTransactionTraceCount(@BindAgentRollupId String agentRollupId,
-            @BindRequest TransactionDataRequest request) throws Exception {
-        TraceQuery query = ImmutableTraceQuery.builder()
-                .transactionType(request.transactionType())
-                .transactionName(request.transactionName())
-                .from(request.from())
-                .to(request.to())
-                .build();
-        long traceCount = traceRepository.readSlowCount(agentRollupId, query).toCompletableFuture().get();
-        boolean includeActiveTraces = shouldIncludeActiveTraces(request);
-        if (includeActiveTraces) {
-            traceCount += liveTraceRepository.getMatchingTraceCount(request.transactionType(),
-                    request.transactionName());
-        }
-        return Long.toString(traceCount);
+            @BindRequest TracePointRequest request) throws Exception {
+        return Long.toString(getTraceCount(TraceKind.SLOW, agentRollupId, request));
     }
 
     @GET(path = "/backend/error/trace-count", permission = "agent:error:traces")
     String getErrorTraceCount(@BindAgentRollupId String agentRollupId,
-            @BindRequest TraceQuery query) throws Exception {
-        return Long.toString(traceRepository.readErrorCount(agentRollupId, query).toCompletableFuture().get());
+            @BindRequest TracePointRequest request) throws Exception {
+        return Long.toString(getTraceCount(TraceKind.ERROR, agentRollupId, request));
     }
 
     @GET(path = "/backend/transaction/points", permission = "agent:transaction:traces")
@@ -103,14 +91,52 @@ class TracePointJsonService {
         return getPoints(TraceKind.ERROR, agentRollupId, request);
     }
 
-    private boolean shouldIncludeActiveTraces(TransactionDataRequest request) {
+    private long getTraceCount(TraceKind traceKind, String agentRollupId, TracePointRequest request)
+            throws Exception {
+        TraceQuery query = toTraceQuery(request);
+        TracePointFilter filter = toTracePointFilter(request);
+        if (!hasTracePointFilters(filter)) {
+            long traceCount;
+            if (traceKind == TraceKind.SLOW) {
+                traceCount = traceRepository.readSlowCount(agentRollupId, query).toCompletableFuture()
+                        .get();
+                if (shouldIncludeActiveTraces(query)) {
+                    traceCount += liveTraceRepository.getMatchingTraceCount(request.transactionType(),
+                            request.transactionName());
+                }
+            } else {
+                traceCount = traceRepository.readErrorCount(agentRollupId, query).toCompletableFuture()
+                        .get();
+            }
+            return traceCount;
+        }
+        // Same collection + dedupe as /points so tab count matches the chart (#725)
+        return new Handler(traceKind, agentRollupId, query, filter, 0).count();
+    }
+
+    private boolean shouldIncludeActiveTraces(TraceQuery query) {
         long currentTimeMillis = clock.currentTimeMillis();
-        return (request.to() == 0 || request.to() > currentTimeMillis)
-                && request.from() < currentTimeMillis;
+        return (query.to() == 0 || query.to() > currentTimeMillis)
+                && query.from() < currentTimeMillis;
     }
 
     private String getPoints(TraceKind traceKind, String agentRollupId, TracePointRequest request)
             throws Exception {
+        TraceQuery query = toTraceQuery(request);
+        TracePointFilter filter = toTracePointFilter(request);
+        return new Handler(traceKind, agentRollupId, query, filter, request.limit()).handle();
+    }
+
+    private static TraceQuery toTraceQuery(TracePointRequest request) {
+        return ImmutableTraceQuery.builder()
+                .transactionType(request.transactionType())
+                .transactionName(request.transactionName())
+                .from(request.from())
+                .to(request.to())
+                .build();
+    }
+
+    private static TracePointFilter toTracePointFilter(TracePointRequest request) {
         double durationMillisLow = request.durationMillisLow();
         long durationNanosLow = Math.round(durationMillisLow * NANOSECONDS_PER_MILLISECOND);
         Long durationNanosHigh = null;
@@ -118,13 +144,7 @@ class TracePointJsonService {
         if (durationMillisHigh != null) {
             durationNanosHigh = Math.round(durationMillisHigh * NANOSECONDS_PER_MILLISECOND);
         }
-        TraceQuery query = ImmutableTraceQuery.builder()
-                .transactionType(request.transactionType())
-                .transactionName(request.transactionName())
-                .from(request.from())
-                .to(request.to())
-                .build();
-        TracePointFilter filter = ImmutableTracePointFilter.builder()
+        return ImmutableTracePointFilter.builder()
                 .durationNanosLow(durationNanosLow)
                 .durationNanosHigh(durationNanosHigh)
                 .headlineComparator(request.headlineComparator())
@@ -137,7 +157,16 @@ class TracePointJsonService {
                 .attributeValueComparator(request.attributeValueComparator())
                 .attributeValue(request.attributeValue())
                 .build();
-        return new Handler(traceKind, agentRollupId, query, filter, request.limit()).handle();
+    }
+
+    private static boolean hasTracePointFilters(TracePointFilter filter) {
+        return filter.durationNanosLow() > 0
+                || filter.durationNanosHigh() != null
+                || !Strings.isNullOrEmpty(filter.headline())
+                || !Strings.isNullOrEmpty(filter.errorMessage())
+                || !Strings.isNullOrEmpty(filter.user())
+                || !Strings.isNullOrEmpty(filter.attributeName())
+                || !Strings.isNullOrEmpty(filter.attributeValue());
     }
 
     private class Handler {
@@ -158,6 +187,21 @@ class TracePointJsonService {
         }
 
         private String handle() throws Exception {
+            CollectedPoints collected = collect();
+            int traceExpirationHours = configRepository.getStorageConfig().traceExpirationHours();
+            boolean expired = collected.points.isEmpty() && collected.activeTracePoints.isEmpty()
+                    && traceExpirationHours != 0 && query
+                    .to() < clock.currentTimeMillis() - HOURS.toMillis(traceExpirationHours);
+            return writeResponse(collected.points, collected.activeTracePoints,
+                    collected.limitExceeded, expired);
+        }
+
+        private long count() throws Exception {
+            CollectedPoints collected = collect();
+            return collected.points.size() + collected.activeTracePoints.size();
+        }
+
+        private CollectedPoints collect() throws Exception {
             boolean captureActiveTracePoints = shouldCaptureActiveTracePoints();
             List<TracePoint> activeTracePoints = Lists.newArrayList();
             long captureTime = 0;
@@ -175,10 +219,7 @@ class TracePointJsonService {
                     getStoredAndPendingPoints(captureTime, captureActiveTracePoints);
             List<TracePoint> points = Lists.newArrayList(queryResult.records());
             removeDuplicatesBetweenActiveAndNormalTracePoints(activeTracePoints, points);
-            int traceExpirationHours = configRepository.getStorageConfig().traceExpirationHours();
-            boolean expired = points.isEmpty() && traceExpirationHours != 0 && query
-                    .to() < clock.currentTimeMillis() - HOURS.toMillis(traceExpirationHours);
-            return writeResponse(points, activeTracePoints, queryResult.moreAvailable(), expired);
+            return new CollectedPoints(points, activeTracePoints, queryResult.moreAvailable());
         }
 
         private boolean shouldCaptureActiveTracePoints() {
@@ -327,6 +368,19 @@ class TracePointJsonService {
         }
     }
 
+    private static class CollectedPoints {
+        private final List<TracePoint> points;
+        private final List<TracePoint> activeTracePoints;
+        private final boolean limitExceeded;
+
+        private CollectedPoints(List<TracePoint> points, List<TracePoint> activeTracePoints,
+                boolean limitExceeded) {
+            this.points = points;
+            this.activeTracePoints = activeTracePoints;
+            this.limitExceeded = limitExceeded;
+        }
+    }
+
     // same as TracePointQuery but with milliseconds instead of nanoseconds
     @Value.Immutable
     public abstract static class TracePointRequest {
@@ -335,7 +389,10 @@ class TracePointJsonService {
         public abstract @Nullable String transactionName();
         public abstract long from();
         public abstract long to();
-        public abstract double durationMillisLow();
+        @Value.Default
+        public double durationMillisLow() {
+            return 0;
+        }
         public abstract @Nullable Double durationMillisHigh();
         public abstract @Nullable StringComparator headlineComparator();
         public abstract @Nullable String headline();
@@ -347,6 +404,10 @@ class TracePointJsonService {
         public abstract @Nullable StringComparator attributeValueComparator();
         public abstract @Nullable String attributeValue();
 
-        public abstract int limit();
+        // 0 means no limit (used by filtered trace-count)
+        @Value.Default
+        public int limit() {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- **#766**: `/health` no longer always returns 200 when Cassandra is down — await the active-agent rollup query, probe `system.local`, and return plain-text OK / 503 with a server log instead of a blank page.
- **#725**: Slow/Error traces tab count now respects filters (same collect/dedupe path as `/points` when filters are set), syncs from the chart when under the result limit, and maps `custom-attribute-*` URL bookmarks correctly. Adds an ⓘ filter-help popover on the traces criteria row.
- **#706**: JUL `JavaLoggingAspect` catches `Formatter.formatMessage` failures (e.g. null message key + ResourceBundle) and falls back to the raw message; regression IT included.

Fixes #766
Fixes #725
Fixes #706

## Test plan
- [x] Embedded sandbox: `/health` returns `200` + body `Glowroot OK` (`text/plain`)
- [x] Slow traces: apply headline / user / nonsense filters → chart filters correctly; attribute dropdown no longer NPEs on tab count
- [x] ⓘ filter help popover opens, sized to content (not clipped by Bootstrap max-width)
- [x] `JavaLoggingIT#testLogWithNullMessageAndResourceBundle` passes
- [ ] Manual: confirm filtered tab count is acceptable (known rare ±1 vs live active/pending left as-is)
- [ ] Central: `/health` returns non-200 when Cassandra is unreachable (not exercised in embedded sandbox)
