### PR TITLE
[BUGFIX] JAX-RS Spring CGLIB paths, @Scheduled on @Bean, WebServiceTemplate Service Calls

### DIFF
--- a/agent/plugins/http-client-plugin/pom.xml
+++ b/agent/plugins/http-client-plugin/pom.xml
@@ -210,6 +210,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.ws</groupId>
+      <artifactId>spring-ws-core</artifactId>
+      <version>3.1.8</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <!-- axis dependency -->
       <groupId>javax.xml.rpc</groupId>
       <artifactId>javax.xml.rpc-api</artifactId>
@@ -479,6 +485,7 @@
             <configuration>
               <testExcludes>
                 <exclude>org/glowroot/agent/plugin/httpclient/RestTemplatePluginIT.java</exclude>
+                <exclude>org/glowroot/agent/plugin/httpclient/WebServiceTemplatePluginIT.java</exclude>
               </testExcludes>
             </configuration>
           </plugin>

--- a/agent/plugins/http-client-plugin/src/main/java/org/glowroot/agent/plugin/httpclient/WebServiceTemplateAspect.java
+++ b/agent/plugins/http-client-plugin/src/main/java/org/glowroot/agent/plugin/httpclient/WebServiceTemplateAspect.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.httpclient;
+
+import org.glowroot.agent.plugin.api.Agent;
+import org.glowroot.agent.plugin.api.MessageSupplier;
+import org.glowroot.agent.plugin.api.ThreadContext;
+import org.glowroot.agent.plugin.api.TimerName;
+import org.glowroot.agent.plugin.api.TraceEntry;
+import org.glowroot.agent.plugin.api.checker.Nullable;
+import org.glowroot.agent.plugin.api.weaving.BindParameter;
+import org.glowroot.agent.plugin.api.weaving.BindThrowable;
+import org.glowroot.agent.plugin.api.weaving.BindTraveler;
+import org.glowroot.agent.plugin.api.weaving.OnBefore;
+import org.glowroot.agent.plugin.api.weaving.OnReturn;
+import org.glowroot.agent.plugin.api.weaving.OnThrow;
+import org.glowroot.agent.plugin.api.weaving.Pointcut;
+import org.glowroot.agent.plugin.httpclient.bclglowrootbcl.Uris;
+
+// Spring WebServiceTemplate (SOAP) — RestTemplate is covered via HttpURLConnection;
+// WebServiceTemplate needs its own service-call entry so calls show under Service Calls (#812).
+public class WebServiceTemplateAspect {
+
+    @Pointcut(className = "org.springframework.ws.client.core.WebServiceTemplate",
+            methodName = "sendAndReceive",
+            methodParameterTypes = {"java.lang.String",
+                    "org.springframework.ws.client.core.WebServiceMessageCallback",
+                    "org.springframework.ws.client.core.WebServiceMessageExtractor"},
+            nestingGroup = "http-client", timerName = "http client request")
+    public static class SendAndReceiveAdvice {
+
+        private static final TimerName timerName = Agent.getTimerName(SendAndReceiveAdvice.class);
+
+        @OnBefore
+        public static TraceEntry onBefore(ThreadContext context,
+                @BindParameter @Nullable String uri) {
+            String safeUri = uri == null ? "" : uri;
+            return context.startServiceCallEntry("HTTP", "POST " + Uris.stripQueryString(safeUri),
+                    MessageSupplier.create("http client request: POST {}", safeUri), timerName);
+        }
+
+        @OnReturn
+        public static void onReturn(@BindTraveler TraceEntry traceEntry) {
+            traceEntry.end();
+        }
+
+        @OnThrow
+        public static void onThrow(@BindThrowable Throwable t,
+                @BindTraveler TraceEntry traceEntry) {
+            traceEntry.endWithError(t);
+        }
+    }
+}

--- a/agent/plugins/http-client-plugin/src/main/resources/META-INF/glowroot.plugin.json
+++ b/agent/plugins/http-client-plugin/src/main/resources/META-INF/glowroot.plugin.json
@@ -12,6 +12,7 @@
     "org.glowroot.agent.plugin.httpclient.OkHttpClientAspect",
     "org.glowroot.agent.plugin.httpclient.OkHttpClient2xAspect",
     "org.glowroot.agent.plugin.httpclient.AxisClientAspect",
+    "org.glowroot.agent.plugin.httpclient.WebServiceTemplateAspect",
     "org.glowroot.agent.plugin.httpclient.WiremockApacheHttpClientAspect"
   ],
   "collocate": true

--- a/agent/plugins/http-client-plugin/src/test/java/org/glowroot/agent/plugin/httpclient/WebServiceTemplatePluginIT.java
+++ b/agent/plugins/http-client-plugin/src/test/java/org/glowroot/agent/plugin/httpclient/WebServiceTemplatePluginIT.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.httpclient;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Iterator;
+
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.ws.WebServiceMessage;
+import org.springframework.ws.WebServiceMessageFactory;
+import org.springframework.ws.client.core.WebServiceTemplate;
+import org.springframework.ws.transport.WebServiceConnection;
+import org.springframework.ws.transport.WebServiceMessageSender;
+
+import org.glowroot.agent.it.harness.AppUnderTest;
+import org.glowroot.agent.it.harness.Container;
+import org.glowroot.agent.it.harness.Containers;
+import org.glowroot.agent.it.harness.TransactionMarker;
+import org.glowroot.wire.api.model.TraceOuterClass.Trace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WebServiceTemplatePluginIT {
+
+    private static Container container;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        container = Containers.create();
+    }
+
+    @AfterAll
+    public static void tearDown() throws Exception {
+        container.close();
+    }
+
+    @AfterEach
+    public void afterEachTest() throws Exception {
+        container.checkAndReset();
+    }
+
+    @Test
+    public void shouldCaptureWebServiceTemplateCall() throws Exception {
+        // when
+        Trace trace = container.execute(ExecuteWebServiceCall.class);
+
+        // then
+        Iterator<Trace.Entry> i = trace.getEntryList().iterator();
+
+        Trace.Entry entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage())
+                .isEqualTo("http client request: POST http://example.test/soap");
+
+        assertThat(i.hasNext()).isFalse();
+    }
+
+    public static class ExecuteWebServiceCall implements AppUnderTest, TransactionMarker {
+        @Override
+        public void executeApp() throws Exception {
+            transactionMarker();
+        }
+
+        @Override
+        public void transactionMarker() throws Exception {
+            // Avoid SAAJ/MessageFactory init on modern JDKs — stub factory + sender (#812).
+            WebServiceTemplate template = new WebServiceTemplate(new StubMessageFactory());
+            template.setMessageSender(new StubMessageSender());
+            template.sendSourceAndReceiveToResult("http://example.test/soap",
+                    new StreamSource(new ByteArrayInputStream("<request/>".getBytes("UTF-8"))),
+                    new StreamResult(new ByteArrayOutputStream()));
+        }
+    }
+
+    private static class StubMessageFactory implements WebServiceMessageFactory {
+        @Override
+        public WebServiceMessage createWebServiceMessage() {
+            return new StubMessage();
+        }
+        @Override
+        public WebServiceMessage createWebServiceMessage(InputStream inputStream)
+                throws IOException {
+            return new StubMessage();
+        }
+    }
+
+    private static class StubMessage implements WebServiceMessage {
+        @Override
+        public Source getPayloadSource() {
+            return new StreamSource(new ByteArrayInputStream("<response/>".getBytes()));
+        }
+        @Override
+        public Result getPayloadResult() {
+            return new StreamResult(new ByteArrayOutputStream());
+        }
+        @Override
+        public void writeTo(OutputStream outputStream) throws IOException {}
+    }
+
+    private static class StubMessageSender implements WebServiceMessageSender {
+        @Override
+        public WebServiceConnection createConnection(URI uri) {
+            return new StubConnection(uri);
+        }
+        @Override
+        public boolean supports(URI uri) {
+            return true;
+        }
+    }
+
+    private static class StubConnection implements WebServiceConnection {
+        private final URI uri;
+        StubConnection(URI uri) {
+            this.uri = uri;
+        }
+        @Override
+        public void send(WebServiceMessage message) throws IOException {}
+        @Override
+        public WebServiceMessage receive(WebServiceMessageFactory messageFactory)
+                throws IOException {
+            return messageFactory.createWebServiceMessage();
+        }
+        @Override
+        public URI getUri() throws URISyntaxException {
+            return uri;
+        }
+        @Override
+        public boolean hasError() {
+            return false;
+        }
+        @Override
+        public String getErrorMessage() {
+            return null;
+        }
+        @Override
+        public void close() {}
+    }
+}

--- a/agent/plugins/jaxrs-plugin/src/main/java/org/glowroot/agent/plugin/jaxrs/ResourceMethodMeta.java
+++ b/agent/plugins/jaxrs-plugin/src/main/java/org/glowroot/agent/plugin/jaxrs/ResourceMethodMeta.java
@@ -97,6 +97,21 @@ public class ResourceMethodMeta {
         } catch (Throwable t) {
             logger.error(t.getMessage(), t);
         }
+        // Spring CGLIB/JDK proxies put @Path on the user superclass/interfaces, not the
+        // runtime enhancer class (see #1136).
+        Class<?> superclass = clazz.getSuperclass();
+        if (superclass != null && superclass != Object.class) {
+            String path = getPath(superclass);
+            if (path != null) {
+                return path;
+            }
+        }
+        for (Class<?> iface : clazz.getInterfaces()) {
+            String path = getPath(iface);
+            if (path != null) {
+                return path;
+            }
+        }
         return null;
     }
 

--- a/agent/plugins/jaxrs-plugin/src/test/java/org/glowroot/agent/plugin/jaxrs/ResourceMethodMetaTest.java
+++ b/agent/plugins/jaxrs-plugin/src/test/java/org/glowroot/agent/plugin/jaxrs/ResourceMethodMetaTest.java
@@ -15,7 +15,18 @@
  */
 package org.glowroot.agent.plugin.jaxrs;
 
+import java.util.Collections;
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
 import org.junit.jupiter.api.Test;
+
+import org.glowroot.agent.plugin.api.MethodInfo;
+import org.glowroot.agent.plugin.api.checker.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,4 +49,50 @@ public class ResourceMethodMetaTest {
         assertThat(ResourceMethodMeta.combine("/abc", "")).isEqualTo("/abc");
         assertThat(ResourceMethodMeta.combine("", "/xyz")).isEqualTo("/xyz");
     }
+
+    @Test
+    public void shouldReadClassPathFromSuperclassLikeSpringCglibProxy() {
+        ResourceMethodMeta meta = new ResourceMethodMeta(methodInfo(OrdersProxy.class, "getOrder",
+                long.class));
+        assertThat(meta.getPath()).isEqualTo("/orders/*");
+        assertThat(meta.hasClassPathAnnotation()).isTrue();
+    }
+
+    private static MethodInfo methodInfo(final Class<?> declaringClass, final String name,
+            final Class<?>... parameterTypes) {
+        return new MethodInfo() {
+            @Override
+            public String getName() {
+                return name;
+            }
+            @Override
+            public Class<?> getReturnType() {
+                return Response.class;
+            }
+            @Override
+            public List<Class<?>> getParameterTypes() {
+                return Collections.<Class<?>>singletonList(parameterTypes[0]);
+            }
+            @Override
+            public String getDeclaringClassName() {
+                return declaringClass.getName();
+            }
+            @Override
+            public @Nullable ClassLoader getLoader() {
+                return declaringClass.getClassLoader();
+            }
+        };
+    }
+
+    @Path("/orders")
+    public static class OrdersResource {
+        @GET
+        @Path("/{id}")
+        public Response getOrder(@PathParam("id") long id) {
+            return Response.ok().build();
+        }
+    }
+
+    // mimics OrderController$$EnhancerBySpringCGLIB$$… (no annotations on the subclass)
+    public static class OrdersProxy extends OrdersResource {}
 }

--- a/agent/plugins/spring-plugin/src/main/resources/META-INF/glowroot.plugin.json
+++ b/agent/plugins/spring-plugin/src/main/resources/META-INF/glowroot.plugin.json
@@ -37,15 +37,13 @@
       "timerName": "jms message"
     },
     {
-      "classAnnotation": "org.springframework.stereotype.Component|org.springframework.stereotype.Controller|org.springframework.stereotype.Repository|org.springframework.stereotype.Service|org.springframework.web.bind.annotation.RestController",
-      "methodAnnotation": "org.springframework.scheduling.annotation.Scheduled",
-      "methodParameterTypes": [
-        ".."
-      ],
+      "className": "org.springframework.scheduling.support.ScheduledMethodRunnable",
+      "methodName": "run",
+      "methodParameterTypes": [],
       "captureKind": "transaction",
       "transactionType": "Background",
-      "transactionNameTemplate": "Spring scheduled: {{this.class.simpleName}}#{{methodName}}",
-      "traceEntryMessageTemplate": "Spring scheduled: {{this.class.name}}.{{methodName}}()",
+      "transactionNameTemplate": "Spring scheduled: {{this.target.class.simpleName}}#{{this.method.name}}",
+      "traceEntryMessageTemplate": "Spring scheduled: {{this.method}}",
       "timerName": "spring scheduled"
     },
     {

--- a/agent/plugins/spring-plugin/src/test/java/org/glowroot/agent/plugin/spring/ScheduledWithoutStereotypeIT.java
+++ b/agent/plugins/spring-plugin/src/test/java/org/glowroot/agent/plugin/spring/ScheduledWithoutStereotypeIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.plugin.spring;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.support.ScheduledMethodRunnable;
+
+import org.glowroot.agent.it.harness.AppUnderTest;
+import org.glowroot.agent.it.harness.Container;
+import org.glowroot.agent.it.harness.Containers;
+import org.glowroot.wire.api.model.TraceOuterClass.Trace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// Spring invokes @Scheduled via ScheduledMethodRunnable — covers @Bean beans without stereotypes (#955).
+public class ScheduledWithoutStereotypeIT {
+
+    private static Container container;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        container = Containers.create();
+    }
+
+    @AfterAll
+    public static void tearDown() throws Exception {
+        container.close();
+    }
+
+    @AfterEach
+    public void afterEachTest() throws Exception {
+        container.checkAndReset();
+    }
+
+    @Test
+    public void shouldCaptureScheduledWithoutComponent() throws Exception {
+        Trace trace = container.execute(CallScheduledWithoutStereotype.class);
+        assertThat(trace.getHeader().getTransactionType()).isEqualTo("Background");
+        assertThat(trace.getHeader().getTransactionName())
+                .isEqualTo("Spring scheduled: FooService#foo");
+    }
+
+    public static class CallScheduledWithoutStereotype implements AppUnderTest {
+        @Override
+        public void executeApp() throws Exception {
+            Method method = FooService.class.getMethod("foo");
+            new ScheduledMethodRunnable(new FooService(), method).run();
+        }
+    }
+
+    // no @Component / @Service — same as a @Bean-registered type
+    public static class FooService {
+        @Scheduled(fixedDelay = Long.MAX_VALUE)
+        public void foo() {}
+    }
+}


### PR DESCRIPTION
## Summary
- **#1136**: Read JAX-RS `@Path` from superclass/interfaces so Spring CGLIB proxies get correct transaction names.
- **#955**: Instrument `ScheduledMethodRunnable#run` so `@Scheduled` on `@Bean` types (no stereotype) appear as Background transactions.
- **#812**: Add http-client aspect on `WebServiceTemplate.sendAndReceive` so SOAP calls show under Service Calls.

## Test plan
- [x] `mvn test -Dtest=ResourceMethodMetaTest -pl :glowroot-agent-jaxrs-plugin`
- [x] `mvn test -Dtest=ScheduledWithoutStereotypeIT -pl :glowroot-agent-spring-plugin`
- [x] `mvn test -Dtest=WebServiceTemplatePluginIT -pl :glowroot-agent-http-client-plugin`
- [ ] Manual: Jersey + Spring Boot controllers with class-level `@Path` — distinct txn names
- [ ] Manual: `@Bean` + `@Scheduled` without `@Component` — Background txn
- [ ] Manual: `WebServiceTemplate` outbound call — Service Calls entry

Fixes #1136
Fixes #955
Fixes #812