### PR TITLE
[BUGFIX] Expunge cleared WeakRefs in active-transaction queue (#1110)

### DIFF
--- a/agent/core/src/main/java/org/glowroot/agent/util/IterableWithSelfRemovableEntries.java
+++ b/agent/core/src/main/java/org/glowroot/agent/util/IterableWithSelfRemovableEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package org.glowroot.agent.util;
 
-import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.Iterator;
@@ -57,21 +56,48 @@ public class IterableWithSelfRemovableEntries<E> implements Iterable<E> {
         return new ElementIterator();
     }
 
+    // package-private for tests (#1110)
+    int linkedEntryCountForTest() {
+        synchronized (lock) {
+            expungeStaleEntries();
+            int count = 0;
+            Entry currEntry = headEntry.nextEntry;
+            while (currEntry != null) {
+                count++;
+                currEntry = currEntry.nextEntry;
+            }
+            return count;
+        }
+    }
+
+    // Clears referents via WeakReference.clear() which does not enqueue on ReferenceQueue,
+    // reproducing the pending-window case where get() is null but poll() is empty (#1110).
+    void clearReferentsForTest() {
+        synchronized (lock) {
+            Entry currEntry = headEntry.nextEntry;
+            while (currEntry != null) {
+                if (currEntry.ref != null) {
+                    currEntry.ref.clear();
+                }
+                currEntry = currEntry.nextEntry;
+            }
+        }
+    }
+
     // requires lock
     private void expungeStaleEntries() {
-        Reference<? extends E> ref = queue.poll();
-        if (ref == null) {
-            return;
-        }
-        // drain the queue, since going to loop over and clean up everything anyways
+        // Drain ReferenceQueue if the JVM has enqueued cleared refs. Always walk the list as well:
+        // WeakReference.get() can already be null while the ref is still pending on the queue
+        // (or cleared without enqueue), which used to early-return and leave tombstones (#1110).
         while (queue.poll() != null) {
         }
         Entry currEntry = headEntry.nextEntry;
         while (currEntry != null) {
+            Entry next = currEntry.nextEntry;
             if (currEntry.getElement() == null) {
                 currEntry.remove();
             }
-            currEntry = currEntry.nextEntry;
+            currEntry = next;
         }
     }
 

--- a/agent/core/src/test/java/org/glowroot/agent/util/IterableWithSelfRemovableEntriesTest.java
+++ b/agent/core/src/test/java/org/glowroot/agent/util/IterableWithSelfRemovableEntriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,5 +38,22 @@ public class IterableWithSelfRemovableEntriesTest {
             entries.get(9 - i).remove();
         }
         assertThat(collection.iterator().hasNext()).isFalse();
+    }
+
+    // Cleared WeakReferences may not yet appear on ReferenceQueue (JVM pending window). Expunge
+    // must still unlink those tombstone Entry nodes or the active-transaction chain leaks (#1110).
+    @Test
+    public void testExpungeClearedReferencesWithoutQueueNotification() {
+        IterableWithSelfRemovableEntries<Object> collection =
+                new IterableWithSelfRemovableEntries<Object>();
+        for (int i = 0; i < 50; i++) {
+            collection.add(new Object());
+        }
+        // Simulate cleared refs that are not (yet) on ReferenceQueue.
+        collection.clearReferentsForTest();
+        Object live = new Object();
+        collection.add(live);
+        assertThat(collection.linkedEntryCountForTest()).isEqualTo(1);
+        assertThat(Lists.newArrayList(collection)).containsExactly(live);
     }
 }


### PR DESCRIPTION
## Summary
- Fix `IterableWithSelfRemovableEntries.expungeStaleEntries()` early-return when `ReferenceQueue.poll()` is empty while `WeakReference.get()` is already null (tombstone leak on the active-transaction chain) (#1110).
- Always walk the linked entries and unlink cleared referents; capture `next` before `remove()`.
- Deterministic unit test via `WeakReference.clear()` (no enqueue) to reproduce the pending-window case.

## Test plan
- [x] `mvn test -Dtest=IterableWithSelfRemovableEntriesTest` in `agent/core` (glowroot-agent-core-unshaded) -- red before fix (count 51), green after (count 1)
- [ ] Reviewer: sanity-check no behavior change for normal `remove()` path (existing test still passes)

Closes #1110