### PR TITLE
[BUGFIX] Add Log4jIT for per-logger level vs Glowroot capture (#1201)

### DIFF
--- a/agent/plugins/logger-plugin/src/test/java/org/glowroot/agent/plugin/logger/Log4jIT.java
+++ b/agent/plugins/logger-plugin/src/test/java/org/glowroot/agent/plugin/logger/Log4jIT.java
@@ -556,10 +556,19 @@ public class Log4jIT {
         }
         @Override
         public void transactionMarker() {
-            Logger.getRootLogger().setLevel(Level.DEBUG);
-            logger.setLevel(Level.ERROR);
-            logger.debug("should-not-appear");
-            logger.info("should-not-appear-either");
+            // Restore levels: Log4j hierarchy is JVM-global and shared across ITs in one container.
+            Logger root = Logger.getRootLogger();
+            Level previousRoot = root.getLevel();
+            Level previousLogger = logger.getLevel();
+            try {
+                root.setLevel(Level.DEBUG);
+                logger.setLevel(Level.ERROR);
+                logger.debug("should-not-appear");
+                logger.info("should-not-appear-either");
+            } finally {
+                root.setLevel(previousRoot);
+                logger.setLevel(previousLogger);
+            }
         }
     }
 
@@ -571,9 +580,17 @@ public class Log4jIT {
         }
         @Override
         public void transactionMarker() {
-            Logger.getRootLogger().setLevel(Level.DEBUG);
-            logger.setLevel(Level.ERROR);
-            logger.error("should-appear");
+            Logger root = Logger.getRootLogger();
+            Level previousRoot = root.getLevel();
+            Level previousLogger = logger.getLevel();
+            try {
+                root.setLevel(Level.DEBUG);
+                logger.setLevel(Level.ERROR);
+                logger.error("should-appear");
+            } finally {
+                root.setLevel(previousRoot);
+                logger.setLevel(previousLogger);
+            }
         }
     }
 

--- a/agent/plugins/logger-plugin/src/test/java/org/glowroot/agent/plugin/logger/Log4jIT.java
+++ b/agent/plugins/logger-plugin/src/test/java/org/glowroot/agent/plugin/logger/Log4jIT.java
@@ -85,6 +85,30 @@ public class Log4jIT {
         assertThat(i.hasNext()).isFalse();
     }
 
+    // #1201: named logger ERROR + root DEBUG must not capture debug/info (log4j gates before
+    // forcedLog; Glowroot weaves forcedLog only).
+    @Test
+    public void testPerLoggerLevelSkipsDebug() throws Exception {
+        Trace trace = container.execute(ShouldLogDebugWithLoggerError.class);
+        assertThat(trace.getEntryList()).isEmpty();
+    }
+
+    @Test
+    public void testPerLoggerLevelStillCapturesError() throws Exception {
+        container.getConfigService().setPluginProperty(PLUGIN_ID,
+                "traceErrorOnErrorWithoutThrowable", true);
+
+        Trace trace = container.execute(ShouldLogErrorWithLoggerError.class);
+
+        assertThat(trace.getHeader().getError().getMessage()).isEqualTo("should-appear");
+        Iterator<Trace.Entry> i = trace.getEntryList().iterator();
+        Trace.Entry entry = i.next();
+        assertThat(entry.getDepth()).isEqualTo(0);
+        assertThat(entry.getMessage()).isEqualTo(
+                "log error: o.g.a.p.l.Log4jIT$ShouldLogErrorWithLoggerError - should-appear");
+        assertThat(i.hasNext()).isFalse();
+    }
+
     @Test
     public void testLogWithThrowable() throws Exception {
         // given
@@ -521,6 +545,35 @@ public class Log4jIT {
             logger.warn("def");
             logger.error("efg");
             logger.fatal("fgh");
+        }
+    }
+
+    public static class ShouldLogDebugWithLoggerError implements AppUnderTest, TransactionMarker {
+        private static final Logger logger = Logger.getLogger(ShouldLogDebugWithLoggerError.class);
+        @Override
+        public void executeApp() {
+            transactionMarker();
+        }
+        @Override
+        public void transactionMarker() {
+            Logger.getRootLogger().setLevel(Level.DEBUG);
+            logger.setLevel(Level.ERROR);
+            logger.debug("should-not-appear");
+            logger.info("should-not-appear-either");
+        }
+    }
+
+    public static class ShouldLogErrorWithLoggerError implements AppUnderTest, TransactionMarker {
+        private static final Logger logger = Logger.getLogger(ShouldLogErrorWithLoggerError.class);
+        @Override
+        public void executeApp() {
+            transactionMarker();
+        }
+        @Override
+        public void transactionMarker() {
+            Logger.getRootLogger().setLevel(Level.DEBUG);
+            logger.setLevel(Level.ERROR);
+            logger.error("should-appear");
         }
     }
 


### PR DESCRIPTION
## Summary
- Regression IT for #1201: named logger `ERROR` + root `DEBUG` must not produce Glowroot entries for `debug`/`info` (log4j gates before `forcedLog`).
- Positive control: `error` on the same logger is still captured.
- No product code change -- confirms current behavior; Threshold is not Glowroot's capture threshold.

## Test plan
- [x] `mvn test -Dtest=Log4jIT#testPerLoggerLevelSkipsDebug,Log4jIT#testPerLoggerLevelStillCapturesError` in `agent/plugins/logger-plugin`

Related to #1201 (not a product bugfix; locks expected behavior).