### PR TITLE
[FEATURE] Ad hoc report metrics for transaction breakdown timers (#1206)

### DIFF
--- a/ui/app/scripts/app.js
+++ b/ui/app/scripts/app.js
@@ -541,6 +541,7 @@ glowroot.run([
         id: 'transaction:x-percentile',
         display: 'Response time (X\u1d57\u02b0 percentile)'
       },
+      // Breakdown timers from Transactions → average (inclusive / exclusive / count).
       {
         id: 'transaction:timer-inclusive',
         display: 'Breakdown metric time (inclusive)'

--- a/ui/app/scripts/controllers/report/adhoc.js
+++ b/ui/app/scripts/controllers/report/adhoc.js
@@ -341,6 +341,8 @@ glowroot.controller('ReportAdhocCtrl', [
       }
     });
 
+    // Best-effort timer list for the dropdown; mirrors GET /backend/report/timer-names
+    // (stored rollups plus level-0 and live aggregates for recent data).
     $scope.$watchGroup([
       'report.agentRollupIds',
       'report.transactionType',

--- a/ui/src/main/java/org/glowroot/ui/BreakdownTimerMetrics.java
+++ b/ui/src/main/java/org/glowroot/ui/BreakdownTimerMetrics.java
@@ -69,9 +69,12 @@ class BreakdownTimerMetrics {
             Map<String, Double> counts) {
         String name = timer.getName();
         if (!parentTimerNames.contains(name)) {
+            // only add when this timer name isn't appearing under itself via another branch
+            // (same guard as average.js flatten)
             add(inclusive, name, timer.getTotalNanos());
             add(exclusive, name, StackedTimerTotals.selfNanos(timer));
             if (!timer.getExtended()) {
+                // extended nodes carry synthetic counts — skip for timer-count (average.js)
                 add(counts, name, timer.getCount());
             }
         }

--- a/ui/src/main/java/org/glowroot/ui/ReportJsonService.java
+++ b/ui/src/main/java/org/glowroot/ui/ReportJsonService.java
@@ -433,6 +433,7 @@ class ReportJsonService {
         return dataSeries;
     }
 
+    // Same rollup/gap loop as getDataSeriesForAverage; per-point value from BreakdownTimerMetrics.
     private DataSeries getDataSeriesForBreakdownTimer(String agentRollupId, AggregateQuery query,
             String timerName, BreakdownTimerMetrics.Kind kind,
             RollupCaptureTimeFn rollupCaptureTimeFn, ROLLUP rollup, TimeZone timeZone,
@@ -466,6 +467,8 @@ class ReportJsonService {
                     pointValue);
             priorAggregate = aggregate;
         }
+        // COUNT overall is a raw sum across buckets; time metrics use weighted ms per transaction
+        // (same split as transaction:count vs transaction:average).
         if (kind == BreakdownTimerMetrics.Kind.COUNT) {
             double totalCount = 0;
             for (OverviewAggregate aggregate : aggregates) {
@@ -479,12 +482,15 @@ class ReportJsonService {
                 totalNanos += BreakdownTimerMetrics.value(aggregate, timerName, kind);
                 transactionCount += aggregate.transactionCount();
             }
+            // individual aggregate transaction counts cannot be zero, and aggregates is non-empty
+            // (see above conditional), so transactionCount is guaranteed non-zero
             checkState(transactionCount != 0);
             dataSeries.setOverall(totalNanos / (transactionCount * NANOSECONDS_PER_MILLISECOND));
         }
         return dataSeries;
     }
 
+    // Time metrics → ms average per transaction in the bucket; count is a raw total.
     private static double breakdownTimerPointValue(OverviewAggregate aggregate, String timerName,
             BreakdownTimerMetrics.Kind kind) {
         double raw = BreakdownTimerMetrics.value(aggregate, timerName, kind);
@@ -674,6 +680,8 @@ class ReportJsonService {
         }
     }
 
+    // timer-inclusive / timer-exclusive / timer-count need timer-name; time metrics also need
+    // transaction-name so the aggregate query matches Transactions → average breakdown.
     private static void validateBreakdownTimerRequest(ReportRequest request) {
         String metric = request.metric();
         if (!metric.equals("transaction:timer-inclusive")


### PR DESCRIPTION
## Problem

The Transactions → average page already shows breakdown timers (`jdbc query`, `logging`, `nestable`, …) as inclusive time, self time, and count. Report → Ad hoc only offered overall response time / percentile / count / errors. Same aggregate timer trees were sitting in `OverviewAggregate`, but `ReportJsonService` rejected anything outside those metrics, and the UI had the three timer metric IDs commented out as TODO.

So you could see “logging is expensive on this endpoint” in the interactive chart, but you could not trend that timer over a week or export it to CSV.

## What this PR does

Enables the three reserved metrics:

- `transaction:timer-inclusive` — same inclusive `totalNanos` flattening as the breakdown table
- `transaction:timer-exclusive` — self time (`totalNanos - children`), same idea as the stacked chart segments / `StackedTimerTotals`
- `transaction:timer-count` — timer invocation count (skips `extended` nodes, same as the table)

Wire-up:

- `BreakdownTimerMetrics` flattens main-thread root timer trees (including nested / duplicate names under different parents).
- `ReportJsonService` builds the report series from overview aggregates the same way average reports do (rollup, gaps, overall). Inclusive/exclusive points are ms per transaction; count is a raw total for the bucket.
- New `GET /backend/report/timer-names` feeds a **dropdown** (no free-text) from stored rollups **plus** level-0 and live aggregates, so recent timers show up even before coarse report rollups exist.
- Ad hoc UI: show timer select for those metrics; transaction name required for inclusive/exclusive, optional for count; short help for inclusive vs exclusive. CSV uses the existing client-side export from the series.

## Out of scope

Alert conditions on breakdown timers — follow-up if we want them.

## Test plan

- [x] `mvn test -Dtest=BreakdownTimerMetricsTest,ReportJsonServiceTest,StackedTimerTotalsTest -pl :glowroot-ui`
- [x] Sandbox smoke: metrics appear, dropdown lists timers (e.g. `nestable`), validation / help text
- [ ] Re-check on a range with persisted report rollups (series not empty) + CSV
- [ ] Confirm alert config UI unchanged

Closes #1206