### PR TITLE
[DOCS] Remove leftover MetricService error:count FIXME

### DIFF
--- a/common2/src/main/java/org/glowroot/common2/repo/util/MetricService.java
+++ b/common2/src/main/java/org/glowroot/common2/repo/util/MetricService.java
@@ -174,7 +174,7 @@ class MetricService {
                 for (ThroughputAggregate aggregate : aggregates) {
                     totalErrorCount += MoreObjects.firstNonNull(aggregate.errorCount(), 0L);
                 }
-                return (totalErrorCount); //FIXME
+                return totalErrorCount;
             });
         } else {
             ImmutableTraceQuery traceQuery = ImmutableTraceQuery.builder()


### PR DESCRIPTION
## Summary
`MetricService.getErrorCount` still had `return (totalErrorCount); //FIXME` from the 2024 async `CompletionStage` refactor. The aggregation was already correct before that change; the marker and useless parentheses were leftover noise.

This PR drops them. No behavior change.

## Test plan
- [x] `mvn test -pl :glowroot-common2 -Dtest=AlertingServiceTest`
- [ ] Diff is the single-line cleanup in `MetricService.java` only