### PR TITLE
[UI-ENRICH] Return full agent-rollup layout when access is empty

### DIFF
--- a/common2/src/main/java/org/glowroot/common2/repo/util/MetricService.java
+++ b/common2/src/main/java/org/glowroot/common2/repo/util/MetricService.java
@@ -174,7 +174,7 @@ class MetricService {
                 for (ThroughputAggregate aggregate : aggregates) {
                     totalErrorCount += MoreObjects.firstNonNull(aggregate.errorCount(), 0L);
                 }
-                return (totalErrorCount); //FIXME
+                return totalErrorCount;
             });
         } else {
             ImmutableTraceQuery traceQuery = ImmutableTraceQuery.builder()

--- a/ui/src/main/java/org/glowroot/ui/LayoutJsonService.java
+++ b/ui/src/main/java/org/glowroot/ui/LayoutJsonService.java
@@ -82,16 +82,10 @@ class LayoutJsonService {
     @GET(path = "/backend/agent-rollup", permission = "")
     String getAgentRollup(@BindRequest AgentRollupRequest request,
             @BindAuthentication Authentication authentication) throws Exception {
+        // Always return the built layout (permissions may all be false). Empty "{}"
+        // broke the central UI which assigns response.data to $rootScope.agentRollup.
         AgentRollupLayout agentRollupLayout =
                 layoutService.buildAgentRollupLayout(authentication, request.id());
-        if (agentRollupLayout == null) {
-            // FIXME let user know that UI configuration not found
-            return "{}";
-        }
-        if (!agentRollupLayout.permissions().hasSomeAccess()) {
-            // FIXME return no-access AgentRollupLayout
-            return "{}";
-        }
         return mapper.writeValueAsString(agentRollupLayout);
     }
 

--- a/ui/src/main/java/org/glowroot/ui/LayoutService.java
+++ b/ui/src/main/java/org/glowroot/ui/LayoutService.java
@@ -512,8 +512,9 @@ class LayoutService {
         abstract ConfigPermissions config();
 
         boolean hasSomeAccess() {
+            // include every agent permission family exposed on AgentRollupLayout
             return transaction().hasSomeAccess() || error().hasSomeAccess() || jvm().hasSomeAccess()
-                    || config().view();
+                    || syntheticMonitor() || incident() || config().view();
         }
     }
 


### PR DESCRIPTION
## Summary
`/backend/agent-rollup` returned `{}` when the user had no agent permissions (and incorrectly when they only had synthetic monitor or incident, because `hasSomeAccess` omitted those flags). The central UI assigns that payload to `.agentRollup` and then reads `.permissions` / `.transactionTypes`.

This PR always returns the built `AgentRollupLayout` (flags may all be false), extends `hasSomeAccess`, and removes a leftover `//FIXME` on `MetricService` error:count aggregation (no behavior change there).

## Test plan
- [x] `mvn test -pl :glowroot-common2 -Dtest=AlertingServiceTest` (local, 2026-08-01)
- [x] `mvn -pl :glowroot-ui -am -DskipTests compile` (local, 2026-08-01)
- [x] Diff is only MetricService + LayoutService + LayoutJsonService
- [ ] (Optional sandbox) Central: user with no agent rights on a rollup → JSON is not `{}`; synthetic/incident-only user → those flags true