### PR TITLE
[BUGFIX] Re-enable Admin Web save; guard empty embedded port

### DIFF
--- a/ui/app/scripts/controllers/admin/web.js
+++ b/ui/app/scripts/controllers/admin/web.js
@@ -57,7 +57,12 @@ glowroot.controller('AdminWebCtrl', [
               httpErrors.handle(response, deferred);
             });
       } else {
-        var changingPort = $scope.config.port !== $scope.activePort;
+        // gt-number maps a cleared Port input to null; EmbeddedWebConfig defaults missing
+        // port to 4000, which would move the listener off the active port on save
+        if (postData.port === null || typeof postData.port !== 'number') {
+          postData.port = $scope.activePort;
+        }
+        var changingPort = postData.port !== $scope.activePort;
         var previousActivePort = $scope.activePort;
         var changingHttps = $scope.config.https !== $scope.activeHttps;
         $http.post('backend/admin/web', postData)

--- a/ui/app/scripts/controllers/admin/web.js
+++ b/ui/app/scripts/controllers/admin/web.js
@@ -57,9 +57,9 @@ glowroot.controller('AdminWebCtrl', [
               httpErrors.handle(response, deferred);
             });
       } else {
-        // gt-number maps a cleared Port input to null; EmbeddedWebConfig defaults missing
-        // port to 4000, which would move the listener off the active port on save
-        if (postData.port === null || typeof postData.port !== 'number') {
+        // gt-number maps a cleared Port input to null; Jackson then binds null to int 0 and
+        // changePort(0) takes down the UI listener. Keep the active listen port instead.
+        if (postData.port === null || typeof postData.port !== 'number' || postData.port <= 0) {
           postData.port = $scope.activePort;
         }
         var changingPort = postData.port !== $scope.activePort;

--- a/ui/src/main/java/org/glowroot/ui/AdminJsonService.java
+++ b/ui/src/main/java/org/glowroot/ui/AdminJsonService.java
@@ -315,6 +315,10 @@ class AdminJsonService {
             EmbeddedWebConfigDto configDto =
                     mapper.readValue(content, ImmutableEmbeddedWebConfigDto.class);
             EmbeddedWebConfig config = configDto.convert();
+            // null JSON "port" becomes 0 for primitive int; refuse before changePort(0)
+            if (config.port() <= 0) {
+                throw new JsonServiceException(BAD_REQUEST, "port must be a positive integer");
+            }
             if (config.https() && !httpServer.getHttps()) {
                 // validate certificate and private key exist and are valid
                 File certificateFile = getConfFile("ui-cert.pem");

--- a/webdriver-tests/src/test/java/org/glowroot/tests/AdminIT.java
+++ b/webdriver-tests/src/test/java/org/glowroot/tests/AdminIT.java
@@ -25,6 +25,7 @@ import org.glowroot.tests.admin.PagerDutyConfigPage;
 import org.glowroot.tests.admin.SlackConfigPage;
 import org.glowroot.tests.admin.SmtpConfigPage;
 import org.glowroot.tests.admin.StorageConfigPage;
+import org.glowroot.tests.admin.WebConfigPage;
 import org.glowroot.tests.config.ConfigSidebar;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -38,16 +39,32 @@ public class AdminIT extends WebDriverIT {
         App app = app();
         GlobalNavbar globalNavbar = globalNavbar();
         ConfigSidebar configSidebar = new ConfigSidebar(driver);
-        // WebConfigPage page = new WebConfigPage(driver);
+        WebConfigPage page = new WebConfigPage(driver);
 
         app.open();
         globalNavbar.clickAdminConfigLink();
         configSidebar.clickWebLink();
 
-        // FIXME currently save overrides active random port with the value 4000
-        // page.clickSaveButton();
+        // Embedded only: Port is not shown on Central. Historical FIXME was that Save could
+        // apply EmbeddedWebConfig's default port 4000 over the harness's random listen port.
+        if (!WebDriverSetup.useCentral) {
+            assertThat(page.getPortTextField().getAttribute("value"))
+                    .isEqualTo(Integer.toString(getUiPort()));
+        }
+
+        // when
+        page.clickSaveButton();
         // wait for save to finish
-        // SECONDS.sleep(1);
+        SECONDS.sleep(1);
+
+        // then
+        app.open();
+        globalNavbar.clickAdminConfigLink();
+        configSidebar.clickWebLink();
+        if (!WebDriverSetup.useCentral) {
+            assertThat(page.getPortTextField().getAttribute("value"))
+                    .isEqualTo(Integer.toString(getUiPort()));
+        }
     }
 
     @Test

--- a/webdriver-tests/src/test/java/org/glowroot/tests/admin/WebConfigPage.java
+++ b/webdriver-tests/src/test/java/org/glowroot/tests/admin/WebConfigPage.java
@@ -16,6 +16,7 @@
 package org.glowroot.tests.admin;
 
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 import org.glowroot.tests.util.Page;
 
@@ -25,6 +26,10 @@ public class WebConfigPage extends Page {
 
     public WebConfigPage(WebDriver driver) {
         super(driver);
+    }
+
+    public WebElement getPortTextField() {
+        return getWithWait(xpath("//div[@gt-label='Port']//input"));
     }
 
     public void clickSaveButton() {


### PR DESCRIPTION
## Summary
`AdminIT.shouldUpdateWebConfig` had Save commented since 2018. Spike on embedded sandbox (`admin.json` port 4010):

- GET/POST round-trip with port 4010 is fine.
- POST port:null` (what a cleared `gt-number` Port field sends) became `port=0` and `changePort(0)` took down the UI.
- Default webdriver harness is Central-forced (`useCentral=true`), so that Port field is not shown in CI — the FIXME was stale for Central but the embedded bug is real.

This PR re-enables Save, coerces null/non-positive port to `activePort` in embedded `web.js`, and rejects `port <= 0` in `AdminJsonService` with HTTP 400.

## Test plan
- [x] Local sandbox `:4010`: null/0 POST → 400, UI stays up
- [x] `grunt jshint` on `web.js`
- [ ] `AdminIT#shouldUpdateWebConfig` on Central webdriver CI
- [ ] Diff: `web.js`, `AdminJsonService`, `AdminIT`, `WebConfigPage`