### PR TITLE
[UI-ENRICH] Show message when Traces filters are invalid on chart refresh

### DIFF
--- a/ui/app/scripts/controllers/transaction/traces.js
+++ b/ui/app/scripts/controllers/transaction/traces.js
@@ -65,12 +65,31 @@ glowroot.controller('TracesCtrl', [
 
     // using $watch instead of $watchGroup because $watchGroup has confusing behavior regarding oldValues
     // (see https://github.com/angular/angular.js/pull/12643)
+    $scope.filterCriteriaInvalid = false;
+
+    $scope.$watch(function () {
+      return $scope.formCtrl && $scope.formCtrl.$invalid;
+    }, function (invalid) {
+      if (!invalid) {
+        $scope.filterCriteriaInvalid = false;
+        if ($scope.formCtrl && $scope.formCtrl.$$element) {
+          $scope.formCtrl.$$element.removeClass('was-validated');
+        }
+      }
+    });
+
     $scope.$watch('[range.chartFrom, range.chartTo, range.chartRefresh, range.chartAutoRefresh]',
         function (newValues, oldValues) {
-          if ($scope.formCtrl.$invalid) {
-            // TODO display message to user
+          if ($scope.formCtrl && $scope.formCtrl.$invalid) {
+            // Same cue as Refresh (gt-validate-form): show field errors + chart banner.
+            // Chart range changes otherwise look like a no-op when filters are invalid.
+            if ($scope.formCtrl.$$element) {
+              $scope.formCtrl.$$element.addClass('was-validated');
+            }
+            $scope.filterCriteriaInvalid = true;
             return;
           }
+          $scope.filterCriteriaInvalid = false;
           appliedFilter.from = $scope.range.chartFrom;
           appliedFilter.to = $scope.range.chartTo;
           updateLocation();

--- a/ui/app/views/transaction/traces.html
+++ b/ui/app/views/transaction/traces.html
@@ -75,6 +75,14 @@
     </div>
   </div>
 </div>
+<div class="row"
+     ng-if="filterCriteriaInvalid">
+  <div class="offset-xl-4 col-xl-8 mt-4">
+    <div class="gt-chart-warning">
+      Fix the invalid filter criteria below to refresh the chart
+    </div>
+  </div>
+</div>
 <div ng-form="formCtrl"
      gt-form-with-primary-button
      class="mt-4">


### PR DESCRIPTION
﻿## Summary
When the chart time range changes while Traces filter fields are invalid (e.g. non-numeric response time), the UI used to no-op with no feedback. Refresh already surfaces validation; chart-range updates now do the same.

- Mark the filter form `was-validated` (existing field feedback).
- Show a `gt-chart-warning` banner: fix invalid criteria to refresh the chart.
- Clear the banner when the form becomes valid again.

## Test plan
- [x] `grunt jshint` (local)
- [ ] Embedded or Central UI: Traces tab — enter invalid Response time (e.g. `abc`), change chart range — banner + field invalid feedback
- [ ] Fix the field — banner clears; chart can refresh again
- [ ] Refresh button still shows validation error message when invalid
