### PR TITLE
[FEATURE] Add Central delete-agent-meta CLI and Admin Storage UI

### DIFF
--- a/agent/embedded/src/main/java/org/glowroot/agent/embedded/repo/RepoAdminImpl.java
+++ b/agent/embedded/src/main/java/org/glowroot/agent/embedded/repo/RepoAdminImpl.java
@@ -100,6 +100,11 @@ class RepoAdminImpl implements RepoAdmin {
     }
 
     @Override
+    public void deleteAgentMeta(String agentRollupId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void defragH2Data() throws Exception {
         dataSource.defrag();
     }

--- a/central/src/main/java/org/glowroot/central/CentralModule.java
+++ b/central/src/main/java/org/glowroot/central/CentralModule.java
@@ -268,7 +268,9 @@ public class CentralModule {
                     .syntheticResultRepository(repos.getSyntheticResultDao())
                     .incidentRepository(repos.getIncidentDao())
                     .repoAdmin(new RepoAdminImpl(session, repos.getActiveAgentDao(),
-                            repos.getConfigRepository(), session.getCassandraWriteMetrics(), clock))
+                            repos.getAgentConfigDao(), repos.getAgentDisplayDao(),
+                            repos.getEnvironmentDao(), repos.getConfigRepository(),
+                            session.getCassandraWriteMetrics(), clock))
                     .rollupLevelService(repos.getRollupLevelService())
                     .liveTraceRepository(new LiveTraceRepositoryImpl(downstreamService))
                     .liveAggregateRepository(new LiveAggregateRepositoryNop())
@@ -491,6 +493,12 @@ public class CentralModule {
             LazySecretKey lazySecretKey = new LazySecretKeyImpl(symmetricEncryptionKey);
             System.out.println(Encryption.encrypt(plainPassword, lazySecretKey));
             return;
+        } else if (commandName.equals("delete-agent-meta")) {
+            if (args.size() != 1) {
+                System.err.println("delete-agent-meta requires one arg (agent/rollup id), exiting");
+                return;
+            }
+            command = Tools::deleteAgentMeta;
         } else if (commandName.equals("truncate-all-data")) {
             if (!args.isEmpty()) {
                 System.err.println("truncate-all-data does not accept any args, exiting");

--- a/central/src/main/java/org/glowroot/central/repo/ActiveAgentDao.java
+++ b/central/src/main/java/org/glowroot/central/repo/ActiveAgentDao.java
@@ -135,12 +135,14 @@ public class ActiveAgentDao implements ActiveAgentRepository {
 
         Map<String, CompletableFuture<String>> topLevelDisplayFutureMap = new ConcurrentHashMap<>();
         return session.readAsync(boundStatement, profile).thenCompose(compute)
-                .thenCompose(ignored -> {
-                    for (String topLevelId : topLevelIds) {
+                .thenCompose(this::filterAgentIdsWithConfig)
+                .thenCompose(filteredTopLevelIds -> {
+                    for (String topLevelId : filteredTopLevelIds) {
                         topLevelDisplayFutureMap.put(topLevelId,
                                 agentDisplayDao.readLastDisplayPartAsync(topLevelId));
                     }
-                    return CompletableFuture.allOf(topLevelDisplayFutureMap.values().toArray(new CompletableFuture[0]));
+                    return CompletableFuture.allOf(topLevelDisplayFutureMap.values()
+                            .toArray(new CompletableFuture[0]));
                 }).thenApply(ignored -> {
                     List<TopLevelAgentRollup> agentRollups = new ArrayList<>();
                     for (Map.Entry<String, CompletableFuture<String>> entry : topLevelDisplayFutureMap.entrySet()) {
@@ -276,7 +278,11 @@ public class ActiveAgentDao implements ActiveAgentRepository {
         Set<String> directChildAgentRollupIds = new HashSet<>();
         Multimap<String, String> childMultimap = HashMultimap.create();
         Map<String, CompletableFuture<String>> agentDisplayFutureMap = new HashMap<>();
-        return session.readAsync(boundStatement, profile).thenCompose(compute).thenRun(() -> {
+        return session.readAsync(boundStatement, profile).thenCompose(compute)
+                .thenCompose(ids -> filterAgentIdsWithConfig(new HashSet<>(ids)))
+                .thenCompose(filteredAgentIds -> {
+            agentIds.clear();
+            agentIds.addAll(filteredAgentIds);
             for (String agentId : agentIds) {
                 List<String> agentRollupIds = AgentRollupIds.getAgentRollupIds(agentId);
                 allAgentRollupIds.addAll(agentRollupIds);
@@ -290,12 +296,12 @@ public class ActiveAgentDao implements ActiveAgentRepository {
                     }
                 }
             }
-        }).thenCompose(ignored -> {
             for (String agentRollupId : allAgentRollupIds) {
                 agentDisplayFutureMap.put(agentRollupId,
                         agentDisplayDao.readLastDisplayPartAsync(agentRollupId));
             }
-            return CompletableFuture.allOf(agentDisplayFutureMap.values().toArray(new CompletableFuture[0]));
+            return CompletableFuture.allOf(agentDisplayFutureMap.values()
+                    .toArray(new CompletableFuture[0]));
         }).thenApply(ignored -> {
             Map<String, String> agentDisplayMap = new HashMap<>();
             for (Map.Entry<String, CompletableFuture<String>> entry : agentDisplayFutureMap.entrySet()) {
@@ -314,6 +320,33 @@ public class ActiveAgentDao implements ActiveAgentRepository {
             }
             agentRollups.sort(Comparator.comparing(AgentRollup::display));
             return agentRollups;
+        });
+    }
+
+    // Hide agents whose metadata was deleted (active_* rows can linger until TWCS TTL).
+    // Keep rollup parents ("…::") so child filtering can still run underneath.
+    private CompletionStage<Set<String>> filterAgentIdsWithConfig(Set<String> agentIds) {
+        if (agentIds.isEmpty()) {
+            return CompletableFuture.completedFuture(agentIds);
+        }
+        List<CompletableFuture<String>> futures = new ArrayList<>();
+        for (String agentId : agentIds) {
+            if (agentId.endsWith("::")) {
+                futures.add(CompletableFuture.completedFuture(agentId));
+                continue;
+            }
+            futures.add(agentConfigDao.readAsync(agentId)
+                    .thenApply(config -> config == null ? null : agentId)
+                    .toCompletableFuture());
+        }
+        return CompletableFutures.allAsList(futures).thenApply(ids -> {
+            Set<String> filtered = new HashSet<>();
+            for (String id : ids) {
+                if (id != null) {
+                    filtered.add(id);
+                }
+            }
+            return filtered;
         });
     }
 

--- a/central/src/main/java/org/glowroot/central/repo/AgentConfigDao.java
+++ b/central/src/main/java/org/glowroot/central/repo/AgentConfigDao.java
@@ -46,7 +46,8 @@ import java.util.function.Function;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-// TODO agent config records never expire for abandoned agent rollup ids
+// Agent config does not auto-expire. Operators can remove abandoned meta via Admin Storage
+// "Delete agent metadata" or CLI delete-agent-meta.
 public class AgentConfigDao {
 
     private final Session session;
@@ -57,6 +58,7 @@ public class AgentConfigDao {
     private final PreparedStatement updatePS;
     private final PreparedStatement updateCentralOnlyPS;
     private final PreparedStatement markUpdatedPS;
+    private final PreparedStatement deletePS;
 
     private final AsyncCache<String, Optional<AgentConfigAndUpdateToken>> agentConfigCache;
 
@@ -87,9 +89,17 @@ public class AgentConfigDao {
         markUpdatedPS = session.prepare("update agent_config set config_update = false,"
                 + " config_update_token = null where agent_rollup_id = ? if config_update_token"
                 + " = ?");
+        deletePS = session.prepare("delete from agent_config where agent_rollup_id = ?");
 
         agentConfigCache = clusterManager.createPerAgentAsyncCache("agentConfigCache",
                 targetMaxActiveAgentsInPast7Days, new AgentConfigCacheLoader());
+    }
+
+    public CompletionStage<?> delete(String agentRollupId) {
+        BoundStatement boundStatement = deletePS.bind()
+                .setString(0, agentRollupId);
+        return session.writeAsync(boundStatement, CassandraProfile.slow)
+                .thenRun(() -> agentConfigCache.invalidate(agentRollupId));
     }
 
     public CompletionStage<AgentConfig> store(String agentId, AgentConfig agentConfig, boolean overwriteExisting) {

--- a/central/src/main/java/org/glowroot/central/repo/AgentDisplayDao.java
+++ b/central/src/main/java/org/glowroot/central/repo/AgentDisplayDao.java
@@ -37,7 +37,8 @@ import org.glowroot.common2.repo.CassandraProfile;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 // this is just a read-optimization store of the same data in agent_config
-// TODO agent display records never expire for abandoned agent rollup ids
+// Agent display does not auto-expire. Operators can remove abandoned meta via Admin Storage
+// "Delete agent metadata" or CLI delete-agent-meta.
 public class AgentDisplayDao implements AgentDisplayRepository {
 
     private final Session session;
@@ -80,6 +81,13 @@ public class AgentDisplayDao implements AgentDisplayRepository {
             ret = session.writeAsync(boundStatement, CassandraProfile.collector);
         }
         return ret.thenRun(() -> agentDisplayCache.invalidate(agentRollupId));
+    }
+
+    public CompletionStage<?> delete(String agentRollupId) {
+        BoundStatement boundStatement = deletePS.bind()
+                .setString(0, agentRollupId);
+        return session.writeAsync(boundStatement, CassandraProfile.slow)
+                .thenRun(() -> agentDisplayCache.invalidate(agentRollupId));
     }
 
     @Override

--- a/central/src/main/java/org/glowroot/central/repo/EnvironmentDao.java
+++ b/central/src/main/java/org/glowroot/central/repo/EnvironmentDao.java
@@ -31,13 +31,15 @@ import org.glowroot.wire.api.model.CollectorServiceOuterClass.InitMessage.Enviro
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-// TODO environment records never expire for abandoned agent ids
+// Environment does not auto-expire. Operators can remove abandoned meta via Admin Storage
+// "Delete agent metadata" or CLI delete-agent-meta.
 public class EnvironmentDao implements EnvironmentRepository {
 
     private final Session session;
 
     private final PreparedStatement insertPS;
     private final PreparedStatement readPS;
+    private final PreparedStatement deletePS;
 
     EnvironmentDao(Session session) throws Exception {
         this.session = session;
@@ -47,6 +49,13 @@ public class EnvironmentDao implements EnvironmentRepository {
 
         insertPS = session.prepare("insert into environment (agent_id, environment) values (?, ?)");
         readPS = session.prepare("select environment from environment where agent_id = ?");
+        deletePS = session.prepare("delete from environment where agent_id = ?");
+    }
+
+    public CompletionStage<?> delete(String agentId) {
+        BoundStatement boundStatement = deletePS.bind()
+                .setString(0, agentId);
+        return session.writeAsync(boundStatement, CassandraProfile.slow);
     }
 
     public CompletionStage<?> store(String agentId, Environment environment) {

--- a/central/src/main/java/org/glowroot/central/repo/RepoAdminImpl.java
+++ b/central/src/main/java/org/glowroot/central/repo/RepoAdminImpl.java
@@ -41,15 +41,22 @@ public class RepoAdminImpl implements RepoAdmin {
 
     private final Session session;
     private final ActiveAgentDao activeAgentDao;
+    private final AgentConfigDao agentConfigDao;
+    private final AgentDisplayDao agentDisplayDao;
+    private final EnvironmentDao environmentDao;
     private final ConfigRepositoryImpl configRepository;
     private final CassandraWriteMetrics cassandraWriteMetrics;
     private final Clock clock;
 
     public RepoAdminImpl(Session session, ActiveAgentDao activeAgentDao,
-            ConfigRepositoryImpl configRepository, CassandraWriteMetrics cassandraWriteMetrics,
-            Clock clock) {
+            AgentConfigDao agentConfigDao, AgentDisplayDao agentDisplayDao,
+            EnvironmentDao environmentDao, ConfigRepositoryImpl configRepository,
+            CassandraWriteMetrics cassandraWriteMetrics, Clock clock) {
         this.session = session;
         this.activeAgentDao = activeAgentDao;
+        this.agentConfigDao = agentConfigDao;
+        this.agentDisplayDao = agentDisplayDao;
+        this.environmentDao = environmentDao;
         this.configRepository = configRepository;
         this.cassandraWriteMetrics = cassandraWriteMetrics;
         this.clock = clock;
@@ -89,6 +96,13 @@ public class RepoAdminImpl implements RepoAdmin {
     @Override
     public void deleteAllData() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteAgentMeta(String agentRollupId) throws Exception {
+        agentConfigDao.delete(agentRollupId).toCompletableFuture().get();
+        agentDisplayDao.delete(agentRollupId).toCompletableFuture().get();
+        environmentDao.delete(agentRollupId).toCompletableFuture().get();
     }
 
     @Override

--- a/central/src/main/java/org/glowroot/central/repo/RepoAdminImpl.java
+++ b/central/src/main/java/org/glowroot/central/repo/RepoAdminImpl.java
@@ -100,9 +100,14 @@ public class RepoAdminImpl implements RepoAdmin {
 
     @Override
     public void deleteAgentMeta(String agentRollupId) throws Exception {
+        logger.info("deleting agent metadata for id={}", agentRollupId);
         agentConfigDao.delete(agentRollupId).toCompletableFuture().get();
+        logger.info("deleted agent_config for id={}", agentRollupId);
         agentDisplayDao.delete(agentRollupId).toCompletableFuture().get();
+        logger.info("deleted agent_display for id={}", agentRollupId);
         environmentDao.delete(agentRollupId).toCompletableFuture().get();
+        logger.info("deleted environment for id={} (live agents may resend collectInit and recreate metadata)",
+                agentRollupId);
     }
 
     @Override

--- a/central/src/main/java/org/glowroot/central/repo/RepoAdminImpl.java
+++ b/central/src/main/java/org/glowroot/central/repo/RepoAdminImpl.java
@@ -103,10 +103,6 @@ public class RepoAdminImpl implements RepoAdmin {
         agentConfigDao.delete(agentRollupId).toCompletableFuture().get();
         agentDisplayDao.delete(agentRollupId).toCompletableFuture().get();
         environmentDao.delete(agentRollupId).toCompletableFuture().get();
-        // One line is enough for ops; per-table steps are not useful at INFO.
-        // Live agents can recreate rows on the next gauge collect (resendInit → collectInit).
-        logger.info("deleted agent metadata for id={} (agent_config, agent_display, environment);"
-                + " a still-connected agent may recreate it via collectInit", agentRollupId);
     }
 
     @Override

--- a/central/src/main/java/org/glowroot/central/repo/RepoAdminImpl.java
+++ b/central/src/main/java/org/glowroot/central/repo/RepoAdminImpl.java
@@ -100,14 +100,13 @@ public class RepoAdminImpl implements RepoAdmin {
 
     @Override
     public void deleteAgentMeta(String agentRollupId) throws Exception {
-        logger.info("deleting agent metadata for id={}", agentRollupId);
         agentConfigDao.delete(agentRollupId).toCompletableFuture().get();
-        logger.info("deleted agent_config for id={}", agentRollupId);
         agentDisplayDao.delete(agentRollupId).toCompletableFuture().get();
-        logger.info("deleted agent_display for id={}", agentRollupId);
         environmentDao.delete(agentRollupId).toCompletableFuture().get();
-        logger.info("deleted environment for id={} (live agents may resend collectInit and recreate metadata)",
-                agentRollupId);
+        // One line is enough for ops; per-table steps are not useful at INFO.
+        // Live agents can recreate rows on the next gauge collect (resendInit → collectInit).
+        logger.info("deleted agent metadata for id={} (agent_config, agent_display, environment);"
+                + " a still-connected agent may recreate it via collectInit", agentRollupId);
     }
 
     @Override

--- a/central/src/main/java/org/glowroot/central/repo/Tools.java
+++ b/central/src/main/java/org/glowroot/central/repo/Tools.java
@@ -79,6 +79,15 @@ public class Tools {
         return true;
     }
 
+    public boolean deleteAgentMeta(List<String> args) throws Exception {
+        String agentRollupId = args.get(0);
+        repos.getAgentConfigDao().delete(agentRollupId).toCompletableFuture().get();
+        repos.getAgentDisplayDao().delete(agentRollupId).toCompletableFuture().get();
+        repos.getEnvironmentDao().delete(agentRollupId).toCompletableFuture().get();
+        startupLogger.info("deleted agent metadata for {}", agentRollupId);
+        return true;
+    }
+
     public boolean truncateAllData(@SuppressWarnings("unused") List<String> args) throws Exception {
         for (String tableName : session.getAllTableNames()) {
             if (!keepTableNames.contains(tableName)) {

--- a/central/src/main/java/org/glowroot/central/repo/Tools.java
+++ b/central/src/main/java/org/glowroot/central/repo/Tools.java
@@ -84,8 +84,8 @@ public class Tools {
         repos.getAgentConfigDao().delete(agentRollupId).toCompletableFuture().get();
         repos.getAgentDisplayDao().delete(agentRollupId).toCompletableFuture().get();
         repos.getEnvironmentDao().delete(agentRollupId).toCompletableFuture().get();
-        startupLogger.info("deleted agent metadata for {}"
-                + " (live agents may resend collectInit and recreate metadata)", agentRollupId);
+        startupLogger.info("deleted agent metadata for {} (agent_config, agent_display, environment);"
+                + " a still-connected agent may recreate it via collectInit", agentRollupId);
         return true;
     }
 

--- a/central/src/main/java/org/glowroot/central/repo/Tools.java
+++ b/central/src/main/java/org/glowroot/central/repo/Tools.java
@@ -84,7 +84,8 @@ public class Tools {
         repos.getAgentConfigDao().delete(agentRollupId).toCompletableFuture().get();
         repos.getAgentDisplayDao().delete(agentRollupId).toCompletableFuture().get();
         repos.getEnvironmentDao().delete(agentRollupId).toCompletableFuture().get();
-        startupLogger.info("deleted agent metadata for {}", agentRollupId);
+        startupLogger.info("deleted agent metadata for {}"
+                + " (live agents may resend collectInit and recreate metadata)", agentRollupId);
         return true;
     }
 

--- a/common2/src/main/java/org/glowroot/common2/repo/RepoAdmin.java
+++ b/common2/src/main/java/org/glowroot/common2/repo/RepoAdmin.java
@@ -36,6 +36,8 @@ public interface RepoAdmin {
 
     void deleteAllData() throws Exception;
 
+    void deleteAgentMeta(String agentRollupId) throws Exception;
+
     void resizeIfNeeded() throws Exception;
 
     int updateCassandraTwcsWindowSizes() throws Exception;

--- a/ui/app/scripts/controllers/admin/storage.js
+++ b/ui/app/scripts/controllers/admin/storage.js
@@ -18,11 +18,13 @@
 
 glowroot.controller('AdminStorageCtrl', [
   '$scope',
+  '$rootScope',
   '$http',
   '$location',
+  '$timeout',
   'confirmIfHasChanges',
   'httpErrors',
-  function ($scope, $http, $location, confirmIfHasChanges, httpErrors) {
+  function ($scope, $rootScope, $http, $location, $timeout, confirmIfHasChanges, httpErrors) {
 
     // initialize page binding object
     $scope.page = {};
@@ -219,11 +221,38 @@ glowroot.controller('AdminStorageCtrl', [
         $scope.deleteAgentMetaRollups = $scope.deleteAgentMetaRollups.filter(function (agentRollup) {
           return agentRollup.id !== id;
         });
+        removeDeletedAgentFromNavbar(id);
         deferred.resolve('Deleted agent metadata for ' + id);
       }, function (response) {
         httpErrors.handle(response, deferred);
       });
     };
+
+    function removeDeletedAgentFromNavbar(id) {
+      if ($rootScope.topLevelAgentRollups) {
+        $rootScope.setTopLevelAgentRollups($rootScope.topLevelAgentRollups.filter(function (agentRollup) {
+          return agentRollup.id !== id;
+        }));
+      }
+      if ($rootScope.childAgentRollups) {
+        $rootScope.setChildAgentRollups($rootScope.childAgentRollups.filter(function (agentRollup) {
+          return agentRollup.id !== id;
+        }));
+      }
+      $timeout(function () {
+        $('#topLevelAgentRollupDropdown').selectpicker('refresh');
+        $('#childAgentRollupDropdown').selectpicker('refresh');
+      });
+      if ($rootScope.agentRollupId === id || $rootScope.agentId === id) {
+        var search = $location.search();
+        delete search['agent-id'];
+        delete search['agent-rollup-id'];
+        $location.search(search);
+        delete $rootScope.agentRollupId;
+        delete $rootScope.agentId;
+        delete $rootScope.agentRollup;
+      }
+    }
 
     function loadDeleteAgentMetaRollups() {
       if (!$scope.layout.central || !$scope.layout.adminEdit) {

--- a/ui/app/scripts/controllers/admin/storage.js
+++ b/ui/app/scripts/controllers/admin/storage.js
@@ -42,7 +42,8 @@ glowroot.controller('AdminStorageCtrl', [
       centralQuery: false,
       centralProfile: false,
       // Trace TTL is a primary Central control (same weight as rollup); keep open.
-      centralTrace: true
+      centralTrace: true,
+      centralDanger: false
     };
     $scope.toggleSection = function (name) {
       $scope.sectionOpen[name] = !$scope.sectionOpen[name];
@@ -203,6 +204,22 @@ glowroot.controller('AdminStorageCtrl', [
           }, function (response) {
             httpErrors.handle(response, deferred);
           });
+    };
+
+    $scope.deleteAgentMeta = function (deferred) {
+      var id = ($scope.page.deleteAgentMetaId || '').trim();
+      if (!id) {
+        deferred.reject('Enter an agent or rollup id');
+        return;
+      }
+      $http.post('backend/admin/delete-agent-meta', {
+        agentRollupId: id
+      }).then(function () {
+        $scope.page.deleteAgentMetaId = '';
+        deferred.resolve('Deleted agent metadata for ' + id);
+      }, function (response) {
+        httpErrors.handle(response, deferred);
+      });
     };
 
     $scope.defragH2Data = function (deferred) {

--- a/ui/app/scripts/controllers/admin/storage.js
+++ b/ui/app/scripts/controllers/admin/storage.js
@@ -207,20 +207,53 @@ glowroot.controller('AdminStorageCtrl', [
     };
 
     $scope.deleteAgentMeta = function (deferred) {
-      var id = ($scope.page.deleteAgentMetaId || '').trim();
+      var id = $scope.page.deleteAgentMetaId;
       if (!id) {
-        deferred.reject('Enter an agent or rollup id');
+        deferred.reject('Select an agent or rollup');
         return;
       }
       $http.post('backend/admin/delete-agent-meta', {
         agentRollupId: id
       }).then(function () {
         $scope.page.deleteAgentMetaId = '';
+        $scope.deleteAgentMetaRollups = $scope.deleteAgentMetaRollups.filter(function (agentRollup) {
+          return agentRollup.id !== id;
+        });
         deferred.resolve('Deleted agent metadata for ' + id);
       }, function (response) {
         httpErrors.handle(response, deferred);
       });
     };
+
+    function loadDeleteAgentMetaRollups() {
+      if (!$scope.layout.central || !$scope.layout.adminEdit) {
+        return;
+      }
+      $http.get('backend/admin/all-active-agent-rollups')
+          .then(function (response) {
+            var agentRollups = response.data || [];
+            angular.forEach(agentRollups, function (agentRollup) {
+              var indent = '';
+              for (var i = 0; i < agentRollup.depth; i++) {
+                indent += '\u00a0\u00a0\u00a0\u00a0';
+              }
+              agentRollup.indentedDisplay = indent + agentRollup.lastDisplayPart;
+            });
+            $scope.deleteAgentMetaRollups = agentRollups;
+            if ($scope.agentRollupId) {
+              var match = agentRollups.some(function (agentRollup) {
+                return agentRollup.id === $scope.agentRollupId;
+              });
+              if (match) {
+                $scope.page.deleteAgentMetaId = $scope.agentRollupId;
+              }
+            }
+          }, function (response) {
+            httpErrors.handle(response);
+          });
+    }
+
+    loadDeleteAgentMetaRollups();
 
     $scope.defragH2Data = function (deferred) {
       $scope.showH2DiskSpaceAnalysis = false;

--- a/ui/app/template/help/storage-danger.html
+++ b/ui/app/template/help/storage-danger.html
@@ -1,8 +1,13 @@
 <div class="gt-storage-help">
   <div><strong>Danger</strong></div>
   <ul>
-    <li><strong>Delete all data</strong> — permanently removes all captured
+    <li ng-if="!layout.central"><strong>Delete all data</strong> — permanently removes all captured
       Glowroot data on this agent: aggregated transactions, traces, and gauge
       data. Configuration is kept. This cannot be undone.</li>
+    <li ng-if="layout.central"><strong>Delete agent metadata</strong> — removes config, display name,
+      and environment for one agent or rollup id. Does not purge charts or traces
+      (those expire via TTL). Same as CLI
+      <code>java -jar glowroot-central.jar delete-agent-meta &lt;id&gt;</code>.
+      Cannot be undone for metadata.</li>
   </ul>
 </div>

--- a/ui/app/template/help/storage-danger.html
+++ b/ui/app/template/help/storage-danger.html
@@ -4,9 +4,9 @@
     <li ng-if="!layout.central"><strong>Delete all data</strong> — permanently removes all captured
       Glowroot data on this agent: aggregated transactions, traces, and gauge
       data. Configuration is kept. This cannot be undone.</li>
-    <li ng-if="layout.central"><strong>Delete agent metadata</strong> — removes config, display name,
-      and environment for one agent or rollup id. Does not purge charts or traces
-      (those expire via TTL). Same as CLI
+    <li ng-if="layout.central"><strong>Delete agent metadata</strong> — pick an agent from the
+      dropdown (active in the last 7 days), then remove config, display name, and environment.
+      Does not purge charts or traces (those expire via TTL). Same as CLI
       <code>java -jar glowroot-central.jar delete-agent-meta &lt;id&gt;</code>.
       Cannot be undone for metadata.</li>
   </ul>

--- a/ui/app/views/admin/storage.html
+++ b/ui/app/views/admin/storage.html
@@ -530,6 +530,57 @@
         </div>
       </fieldset>
       <fieldset class="gt-fieldset"
+                ng-if="layout.central && layout.adminEdit">
+        <legend class="gt-legend gt-legend-toggle"
+                ng-click="toggleSection('centralDanger')">
+          <span class="fas gt-legend-chevron"
+                ng-class="sectionOpen.centralDanger ? 'fa-chevron-down' : 'fa-chevron-right'"></span>
+          <span class="text-danger">Danger</span>
+          <button type="button"
+                  class="gt-storage-info-btn"
+                  ng-click="$event.stopPropagation()"
+                  uib-popover-template="'template/help/storage-danger.html'"
+                  popover-placement="bottom"
+                  popover-trigger="'outsideClick'">
+            <span title="Help" class="fas fa-question-circle"></span>
+          </button>
+          <span class="text-muted font-weight-normal"
+                ng-if="!sectionOpen.centralDanger"> — delete agent metadata</span>
+        </legend>
+        <div ng-show="sectionOpen.centralDanger">
+          <div class="help-block gt-storage-section-blurb">
+            Remove config, display name, and environment for one abandoned agent or rollup id.
+            Does not purge charts or traces (those follow TTL).
+          </div>
+          <div class="form-group row">
+            <label class="col-form-label col-xl-4">Agent / rollup id</label>
+            <div class="col-xl-8">
+              <input type="text"
+                     class="form-control"
+                     style="max-width: 28em;"
+                     ng-model="page.deleteAgentMetaId"
+                     placeholder="MyApp::pod-xyz"
+                     autocomplete="off">
+            </div>
+          </div>
+          <div class="form-group row">
+            <div class="offset-xl-4 col-xl-8">
+              <div gt-button-group>
+                <div gt-button
+                     gt-label="Delete agent metadata"
+                     gt-click="deleteAgentMeta(deferred)"
+                     gt-btn-class="btn-secondary"
+                     gt-dont-validate-form="true"
+                     gt-confirm-header="Delete agent metadata?"
+                     gt-confirm-body="This removes config, display name, and environment for that id only. Charts and traces are not purged (they expire via TTL). This cannot be undone for metadata."
+                     class="d-inline-block">
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+      <fieldset class="gt-fieldset"
                 ng-if="(layout.adminEdit || layout.offlineViewer) && !layout.central">
         <legend class="gt-legend gt-legend-toggle"
                 ng-click="toggleSection('maintenance')">

--- a/ui/app/views/admin/storage.html
+++ b/ui/app/views/admin/storage.html
@@ -549,18 +549,20 @@
         </legend>
         <div ng-show="sectionOpen.centralDanger">
           <div class="help-block gt-storage-section-blurb">
-            Remove config, display name, and environment for one abandoned agent or rollup id.
-            Does not purge charts or traces (those follow TTL).
+            Remove config, display name, and environment for one agent or rollup
+            (same list as Roles: active in the last 7 days). Does not purge charts or traces
+            (those follow TTL). For ids not listed, use CLI
+            <code>delete-agent-meta</code>.
           </div>
           <div class="form-group row">
-            <label class="col-form-label col-xl-4">Agent / rollup id</label>
+            <label class="col-form-label col-xl-4">Agent / rollup</label>
             <div class="col-xl-8">
-              <input type="text"
-                     class="form-control"
-                     style="max-width: 28em;"
-                     ng-model="page.deleteAgentMetaId"
-                     placeholder="MyApp::pod-xyz"
-                     autocomplete="off">
+              <select class="form-control"
+                      style="max-width: 28em;"
+                      ng-model="page.deleteAgentMetaId"
+                      ng-options="agentRollup.id as agentRollup.indentedDisplay for agentRollup in deleteAgentMetaRollups track by agentRollup.id">
+                <option value="">Select agent…</option>
+              </select>
             </div>
           </div>
           <div class="form-group row">
@@ -571,6 +573,7 @@
                      gt-click="deleteAgentMeta(deferred)"
                      gt-btn-class="btn-secondary"
                      gt-dont-validate-form="true"
+                     gt-disabled="!page.deleteAgentMetaId"
                      gt-confirm-header="Delete agent metadata?"
                      gt-confirm-body="This removes config, display name, and environment for that id only. Charts and traces are not purged (they expire via TTL). This cannot be undone for metadata."
                      class="d-inline-block">

--- a/ui/app/views/admin/storage.html
+++ b/ui/app/views/admin/storage.html
@@ -550,9 +550,10 @@
         <div ng-show="sectionOpen.centralDanger">
           <div class="help-block gt-storage-section-blurb">
             Remove config, display name, and environment for one agent or rollup
-            (same list as Roles: active in the last 7 days). Does not purge charts or traces
-            (those follow TTL). For ids not listed, use CLI
-            <code>delete-agent-meta</code>.
+            (same list as Roles: active in the last 7 days that still have metadata).
+            Does not purge charts or traces (those follow TTL). After delete the agent
+            disappears from the navbar until it reconnects (<code>collectInit</code>).
+            For ids not listed, use CLI <code>delete-agent-meta</code>.
           </div>
           <div class="form-group row">
             <label class="col-form-label col-xl-4">Agent / rollup</label>

--- a/ui/src/main/java/org/glowroot/ui/AdminJsonService.java
+++ b/ui/src/main/java/org/glowroot/ui/AdminJsonService.java
@@ -665,6 +665,18 @@ class AdminJsonService {
         liveAggregateRepository.clearInMemoryData();
     }
 
+    @POST(path = "/backend/admin/delete-agent-meta", permission = "admin:edit:storage")
+    void deleteAgentMeta(@BindRequest DeleteAgentMetaRequest request) throws Exception {
+        if (!central) {
+            throw new JsonServiceException(HttpResponseStatus.NOT_FOUND);
+        }
+        String agentRollupId = request.agentRollupId();
+        if (agentRollupId == null || agentRollupId.trim().isEmpty()) {
+            throw new JsonServiceException(BAD_REQUEST, "agentRollupId is required");
+        }
+        repoAdmin.deleteAgentMeta(agentRollupId.trim());
+    }
+
     @POST(path = "/backend/admin/update-cassandra-twcs-window-sizes",
             permission = "admin:edit:storage")
     String updateCassandraTwcsWindowSizes() throws Exception {
@@ -841,6 +853,12 @@ class AdminJsonService {
         @Nullable
         String transactionType();
         int limit();
+    }
+
+    @Value.Immutable
+    interface DeleteAgentMetaRequest {
+        @Nullable
+        String agentRollupId();
     }
 
     @Value.Immutable

--- a/ui/src/main/java/org/glowroot/ui/AdminJsonService.java
+++ b/ui/src/main/java/org/glowroot/ui/AdminJsonService.java
@@ -666,7 +666,8 @@ class AdminJsonService {
     }
 
     @POST(path = "/backend/admin/delete-agent-meta", permission = "admin:edit:storage")
-    void deleteAgentMeta(@BindRequest DeleteAgentMetaRequest request) throws Exception {
+    void deleteAgentMeta(@BindRequest DeleteAgentMetaRequest request,
+            @BindAuthentication Authentication authentication) throws Exception {
         if (!central) {
             throw new JsonServiceException(HttpResponseStatus.NOT_FOUND);
         }
@@ -676,6 +677,11 @@ class AdminJsonService {
         }
         String id = agentRollupId.trim();
         repoAdmin.deleteAgentMeta(id);
+        // Username here (not in RepoAdmin): CLI has no user; Glowroot audit log also records
+        // POST body when -Dglowroot.log.auditOn=true.
+        logger.info("{} - deleted agent metadata for id={} (agent_config, agent_display, environment);"
+                + " a still-connected agent may recreate it via collectInit",
+                authentication.caseAmbiguousUsername(), id);
     }
 
     @POST(path = "/backend/admin/update-cassandra-twcs-window-sizes",

--- a/ui/src/main/java/org/glowroot/ui/AdminJsonService.java
+++ b/ui/src/main/java/org/glowroot/ui/AdminJsonService.java
@@ -111,7 +111,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.PRECONDITION_FAILED
 @JsonService
 class AdminJsonService {
 
-    private static final Logger logger = LoggerFactory.getLogger(ConfigJsonService.class);
+    private static final Logger logger = LoggerFactory.getLogger(AdminJsonService.class);
     private static final ObjectMapper mapper = ObjectMappers.create();
 
     private static final Ordering<H2Table> orderingByBytesDesc = new Ordering<H2Table>() {
@@ -674,7 +674,10 @@ class AdminJsonService {
         if (agentRollupId == null || agentRollupId.trim().isEmpty()) {
             throw new JsonServiceException(BAD_REQUEST, "agentRollupId is required");
         }
-        repoAdmin.deleteAgentMeta(agentRollupId.trim());
+        String id = agentRollupId.trim();
+        logger.info("admin request: delete agent metadata for id={}", id);
+        repoAdmin.deleteAgentMeta(id);
+        logger.info("admin request completed: delete agent metadata for id={}", id);
     }
 
     @POST(path = "/backend/admin/update-cassandra-twcs-window-sizes",

--- a/ui/src/main/java/org/glowroot/ui/AdminJsonService.java
+++ b/ui/src/main/java/org/glowroot/ui/AdminJsonService.java
@@ -675,9 +675,7 @@ class AdminJsonService {
             throw new JsonServiceException(BAD_REQUEST, "agentRollupId is required");
         }
         String id = agentRollupId.trim();
-        logger.info("admin request: delete agent metadata for id={}", id);
         repoAdmin.deleteAgentMeta(id);
-        logger.info("admin request completed: delete agent metadata for id={}", id);
     }
 
     @POST(path = "/backend/admin/update-cassandra-twcs-window-sizes",

--- a/ui/src/main/java/org/glowroot/ui/RoleConfigJsonService.java
+++ b/ui/src/main/java/org/glowroot/ui/RoleConfigJsonService.java
@@ -42,6 +42,7 @@ import org.glowroot.common2.repo.ActiveAgentRepository.AgentRollup;
 import org.glowroot.common2.repo.ConfigRepository;
 import org.glowroot.common2.repo.ConfigRepository.CannotDeleteLastRoleException;
 import org.glowroot.common2.repo.ConfigRepository.DuplicateRoleNameException;
+import org.glowroot.ui.HttpSessionManager.Authentication;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static java.util.concurrent.TimeUnit.DAYS;
@@ -86,8 +87,13 @@ class RoleConfigJsonService {
         }
     }
 
-    @GET(path = "/backend/admin/all-active-agent-rollups", permission = "admin:edit:role")
-    String getAllAgentRollups() throws Exception {
+    @GET(path = "/backend/admin/all-active-agent-rollups", permission = "")
+    String getAllAgentRollups(@BindAuthentication Authentication authentication) throws Exception {
+        // Shared by Roles and Storage (delete agent metadata)
+        if (!authentication.isAdminPermitted("admin:edit:role")
+                && !authentication.isAdminPermitted("admin:edit:storage")) {
+            throw new JsonServiceException(HttpResponseStatus.FORBIDDEN);
+        }
         return mapper.writeValueAsString(getFlattenedAgentRollups());
     }
 


### PR DESCRIPTION
Central-only: delete stale **agent metadata** (config row, display name, environment) for one agent/rollup id.

**Does**
- CLI: `delete-agent-meta <id>`
- Admin → Storage → Danger → dropdown + confirm
- `POST /backend/admin/delete-agent-meta` (`admin:edit:storage`)
- Dropdown lists agents active in last 7 days that still have metadata
- Idempotent; logs who ran it

**Does NOT**
- Delete traces, rollups, or gauge history for that id
- Cascade to child rollups

Replaces three “never expire” DAO TODOs with “use the UI/CLI”.

## Screenshots

Storage → Danger, confirm, success, UI after delete, log line (user attribution):

<img width="1076" height="831" alt="Screenshot 2026-08-02 123024" src="https://github.com/user-attachments/assets/421ef98b-9d29-4bbe-872d-7988ec6d9ccb" />

<img width="868" height="478" alt="Screenshot 2026-08-02 123052" src="https://github.com/user-attachments/assets/72702ace-a9ac-425e-a149-caed7ae4dd36" />

<img width="919" height="277" alt="Screenshot 2026-08-02 123102" src="https://github.com/user-attachments/assets/ed319524-4348-49fd-ac50-f3adb81520df" />

<img width="1221" height="433" alt="immagine" src="https://github.com/user-attachments/assets/3d5ee9d1-33c4-45a9-a0a4-64720c21080c" />

<img width="1705" height="155" alt="immagine" src="https://github.com/user-attachments/assets/7a2a5686-433f-42ff-a16f-2629ffbc1fe6" />

**Still to verify**
- [ ] CLI on a real central jar
- [ ] Charts/traces for that id untouched after delete