### PR TITLE
[BUGFIX] Fix woven LocalVariableTable and stack-map locals (#1106, #721)

### DIFF
--- a/agent/core/src/main/java/org/glowroot/agent/weaving/WeavingMethodVisitor.java
+++ b/agent/core/src/main/java/org/glowroot/agent/weaving/WeavingMethodVisitor.java
@@ -248,27 +248,10 @@ class WeavingMethodVisitor extends AdviceAdapter {
         visitLabel(outerEndLabel);
         super.visitLocalVariable(name, descriptor, signature, methodStartLabel, outerEndLabel,
                 index);
-        // at the same time, may as well define local vars for enabled and traveler as
-        // applicable
-        for (int i = 0; i < advisors.size(); i++) {
-            Advice advice = advisors.get(i);
-            Integer enabledLocalIndex = enabledLocals.get(advice);
-            if (enabledLocalIndex != null) {
-                super.visitLocalVariable("glowroot$enabled$" + i, Type.BOOLEAN_TYPE.getDescriptor(),
-                        null, methodStartLabel, outerEndLabel, enabledLocalIndex);
-            }
-            Integer travelerLocalIndex = travelerLocals.get(advice);
-            if (travelerLocalIndex != null) {
-                Type travelerType = advice.travelerType();
-                if (travelerType == null) {
-                    logger.error("visitLocalVariable(): traveler local index is not null,"
-                            + " but traveler type is null");
-                } else {
-                    super.visitLocalVariable("glowroot$traveler$" + i, travelerType.getDescriptor(),
-                            null, methodStartLabel, outerEndLabel, travelerLocalIndex);
-                }
-            }
-        }
+        // Do not emit LocalVariableTable entries for advice locals (enabled/traveler). Those
+        // indices come from newLocal() (already remapped); passing them to
+        // LocalVariablesSorter.visitLocalVariable remaps again and corrupts the LVT (wrong /
+        // overlapping slots), which breaks JDWP debuggers — see #1106.
     }
 
     @Override
@@ -1131,31 +1114,12 @@ class WeavingMethodVisitor extends AdviceAdapter {
     public void visitFrame(int type, int nLocal, Object /*@Nullable*/ [] local, int nStack,
             Object /*@Nullable*/ [] stack) {
         checkState(type == F_NEW, "Unexpected frame type: " + type);
-        int nExtraLocal = nLocal - implicitFrameLocals.length;
-        if (implicitFrameLocals.length >= nLocal) {
-            nExtraLocal = 0;
-        } else {
-            int i = 0;
-            int j = 0;
-            while (i < nLocal && j < implicitFrameLocals.length) {
-                Object currLocal = checkNotNull(local)[i++];
-                Object currImplicitFrameLocal = implicitFrameLocals[j++];
-                if (currLocal == TOP
-                        && (currImplicitFrameLocal == LONG || currImplicitFrameLocal == DOUBLE)) {
-                    i++;
-                }
-            }
-            nExtraLocal = nLocal - i;
-        }
-        if (nExtraLocal > 0) {
-            Object[] overlay = new Object[implicitFrameLocals.length + nExtraLocal];
-            System.arraycopy(implicitFrameLocals, 0, overlay, 0, implicitFrameLocals.length);
-            System.arraycopy(checkNotNull(local), nLocal - nExtraLocal, overlay,
-                    implicitFrameLocals.length, nExtraLocal);
-            super.visitFrame(type, overlay.length, overlay, nStack, stack);
-        } else {
-            super.visitFrame(type, implicitFrameLocals.length, implicitFrameLocals, nStack, stack);
-        }
+        // Pass through the original expanded frame locals. Replacing them with
+        // implicitFrameLocals (method-entry this/args types) dropped in-method updates such as
+        // overwriting a parameter slot with a different reference type, which produced
+        // VerifyError on exception handlers (#721). LocalVariablesSorter merges newLocal advice
+        // slots when remapping.
+        super.visitFrame(type, nLocal, local, nStack, stack);
     }
 
     private void pushDefault(Type type) {

--- a/agent/core/src/test/java/org/glowroot/agent/weaving/GenerateParamSlotOverwriteBytecode.java
+++ b/agent/core/src/test/java/org/glowroot/agent/weaving/GenerateParamSlotOverwriteBytecode.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.weaving;
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+
+import org.glowroot.agent.plugin.api.weaving.IsEnabled;
+import org.glowroot.agent.plugin.api.weaving.OnAfter;
+import org.glowroot.agent.plugin.api.weaving.OnBefore;
+import org.glowroot.agent.plugin.api.weaving.OnReturn;
+import org.glowroot.agent.plugin.api.weaving.OnThrow;
+import org.glowroot.agent.plugin.api.weaving.Pointcut;
+import org.glowroot.agent.weaving.ClassLoaders.LazyDefinedClass;
+
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_SUPER;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ASTORE;
+import static org.objectweb.asm.Opcodes.ATHROW;
+import static org.objectweb.asm.Opcodes.CHECKCAST;
+import static org.objectweb.asm.Opcodes.F_FULL;
+import static org.objectweb.asm.Opcodes.GOTO;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.POP;
+import static org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.V1_6;
+
+/**
+ * Repro shape for #721: method parameter local slot is overwritten with a different reference
+ * type inside a try block that has an exception handler (ServletContextListener-style).
+ */
+public class GenerateParamSlotOverwriteBytecode {
+
+    static LazyDefinedClass generate() throws Exception {
+        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        MethodVisitor mv;
+
+        String className = "ParamSlotOverwrite";
+        String iface = Test.class.getName().replace('.', '/');
+
+        cw.visit(V1_6, ACC_PUBLIC + ACC_SUPER, className, null, "java/lang/Object",
+                new String[] {iface});
+
+        {
+            mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(1, 1);
+            mv.visitEnd();
+        }
+        {
+            // void contextInitialized(Runnable event)
+            // try {
+            //   // overwrite slot 1 (event: Runnable) with String (from event.toString())
+            //   event = event.toString(); // as bytecode: toString + astore_1
+            //   ((String) event).length();
+            // } catch (Throwable t) { throw t; }
+            mv = cw.visitMethod(ACC_PUBLIC, "contextInitialized", "(Ljava/lang/Runnable;)V", null,
+                    null);
+            mv.visitCode();
+            Label tryStart = new Label();
+            Label tryEnd = new Label();
+            Label catchHandler = new Label();
+            Label exit = new Label();
+            mv.visitTryCatchBlock(tryStart, tryEnd, catchHandler, "java/lang/Throwable");
+
+            mv.visitLabel(tryStart);
+            mv.visitVarInsn(ALOAD, 1);
+            mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Object", "toString",
+                    "()Ljava/lang/String;", false);
+            mv.visitVarInsn(ASTORE, 1);
+            // frame after overwrite: locals this, String
+            mv.visitFrame(F_FULL, 2, new Object[] {className, "java/lang/String"}, 0, null);
+            mv.visitVarInsn(ALOAD, 1);
+            mv.visitTypeInsn(CHECKCAST, "java/lang/String");
+            mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);
+            mv.visitInsn(POP);
+            mv.visitLabel(tryEnd);
+            mv.visitJumpInsn(GOTO, exit);
+
+            mv.visitLabel(catchHandler);
+            // handler frame must see String in slot 1 (updated type), not Runnable
+            mv.visitFrame(F_FULL, 2, new Object[] {className, "java/lang/String"}, 1,
+                    new Object[] {"java/lang/Throwable"});
+            mv.visitInsn(ATHROW);
+
+            mv.visitLabel(exit);
+            mv.visitFrame(F_FULL, 2, new Object[] {className, "java/lang/String"}, 0, null);
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(2, 2);
+            mv.visitEnd();
+        }
+        cw.visitEnd();
+
+        return ImmutableLazyDefinedClass.builder()
+                .type(Type.getObjectType(className))
+                .bytes(cw.toByteArray())
+                .build();
+    }
+
+    public interface Test {
+        void contextInitialized(Runnable event);
+    }
+
+    @Pointcut(className = "ParamSlotOverwrite", methodName = "contextInitialized",
+            methodParameterTypes = {"java.lang.Runnable"}, timerName = "param-slot-overwrite")
+    public static class ParamSlotOverwriteAdvice {
+        @IsEnabled
+        public static boolean isEnabled() {
+            return true;
+        }
+        @OnBefore
+        public static void onBefore() {
+            SomeAspectThreadLocals.onBeforeCount.increment();
+        }
+        @OnReturn
+        public static void onReturn() {
+            SomeAspectThreadLocals.onReturnCount.increment();
+        }
+        @OnThrow
+        public static void onThrow() {
+            SomeAspectThreadLocals.onThrowCount.increment();
+        }
+        @OnAfter
+        public static void onAfter() {
+            SomeAspectThreadLocals.onAfterCount.increment();
+        }
+    }
+}

--- a/agent/core/src/test/java/org/glowroot/agent/weaving/WeaverTest.java
+++ b/agent/core/src/test/java/org/glowroot/agent/weaving/WeaverTest.java
@@ -15,6 +15,8 @@
  */
 package org.glowroot.agent.weaving;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.List;
@@ -25,9 +27,15 @@ import com.google.common.base.Suppliers;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.io.ByteStreams;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 
 import org.glowroot.agent.bytecode.api.ThreadContextThreadLocal;
 import org.glowroot.agent.config.ConfigService;
@@ -1846,6 +1854,56 @@ public class WeaverTest {
         // do not crash with java.lang.VerifyError
     }
 
+    // ===================== #1106 LocalVariableTable / #721 stack-map =====================
+
+    @Test
+    public void shouldNotEmitGlowrootAdviceNamesInLocalVariableTable() throws Exception {
+        // given
+        byte[] original = readClassBytes(BasicMisc.class);
+        Weaver weaver = newWeaver(BindTravelerAdvice.class);
+        // when
+        byte[] woven = weaver.weave(original, BasicMisc.class.getName().replace('.', '/'), null,
+                null, WeaverTest.class.getClassLoader());
+        // then
+        assertThat(woven).isNotNull();
+        final List<String> lvtNames = Lists.newArrayList();
+        new ClassReader(woven).accept(new ClassVisitor(Opcodes.ASM9) {
+            @Override
+            public MethodVisitor visitMethod(int access, String name, String descriptor,
+                    String signature, String[] exceptions) {
+                if (!"execute1".equals(name)) {
+                    return null;
+                }
+                return new MethodVisitor(Opcodes.ASM9) {
+                    @Override
+                    public void visitLocalVariable(String varName, String desc, String sig,
+                            Label start, Label end, int index) {
+                        lvtNames.add(varName);
+                    }
+                };
+            }
+        }, 0);
+        for (String name : lvtNames) {
+            assertThat(name).doesNotStartWith("glowroot$");
+        }
+    }
+
+    @Test
+    public void shouldWeaveMethodThatOverwritesParameterSlotWithDifferentType() throws Exception {
+        // given (#721): ServletContextListener-style overwrite of param local + exception handler
+        LazyDefinedClass implClass = GenerateParamSlotOverwriteBytecode.generate();
+        // when / then — must not throw VerifyError while defining the woven class
+        GenerateParamSlotOverwriteBytecode.Test test = newWovenObject(implClass,
+                GenerateParamSlotOverwriteBytecode.Test.class,
+                GenerateParamSlotOverwriteBytecode.ParamSlotOverwriteAdvice.class);
+        test.contextInitialized(new Runnable() {
+            @Override
+            public void run() {}
+        });
+        assertThat(SomeAspectThreadLocals.onBeforeCount.get()).isEqualTo(1);
+        assertThat(SomeAspectThreadLocals.onReturnCount.get()).isEqualTo(1);
+    }
+
     public static <S, T extends S> S newWovenObject(Class<T> implClass, Class<S> bridgeClass,
             Class<?> adviceOrShimOrMixinClass, Class<?>... extraBridgeClasses) throws Exception {
         // SomeAspectThreadLocals is passed as bridgeable so that the static thread locals will be
@@ -1936,6 +1994,32 @@ public class WeaverTest {
 
     private static MixinType newMixin(Class<?> clazz) throws Exception {
         return MixinType.create(PluginDetailBuilder.buildMixinClass(clazz));
+    }
+
+    private static Weaver newWeaver(Class<?> adviceClass) throws Exception {
+        List<Advice> advisors = Lists.newArrayList();
+        advisors.add(newAdvice(adviceClass));
+        Supplier<List<Advice>> advisorsSupplier =
+                Suppliers.<List<Advice>>ofInstance(ImmutableList.copyOf(advisors));
+        AnalyzedWorld analyzedWorld = new AnalyzedWorld(advisorsSupplier,
+                ImmutableList.<ShimType>of(), ImmutableList.<MixinType>of(), null);
+        TransactionRegistry transactionRegistry = mock(TransactionRegistry.class);
+        when(transactionRegistry.getCurrentThreadContextHolder())
+                .thenReturn(new ThreadContextThreadLocal().getHolder());
+        return new Weaver(advisorsSupplier, ImmutableList.<ShimType>of(),
+                ImmutableList.<MixinType>of(), analyzedWorld, transactionRegistry,
+                Ticker.systemTicker(), new TimerNameCache(), mock(ConfigService.class));
+    }
+
+    private static byte[] readClassBytes(Class<?> clazz) throws IOException {
+        String resource = clazz.getName().replace('.', '/') + ".class";
+        InputStream in = clazz.getClassLoader().getResourceAsStream(resource);
+        assertThat(in).isNotNull();
+        try {
+            return ByteStreams.toByteArray(in);
+        } finally {
+            in.close();
+        }
     }
 
     private static Class<?> enhanceConstructorAdviceClass(Class<?> adviceClass)


### PR DESCRIPTION
## Summary
- **#1106:** stop emitting `glowroot$enabled$` / `glowroot$traveler$` LocalVariableTable entries. Those used `newLocal()` indices passed through `LocalVariablesSorter.visitLocalVariable`, which remaps again and corrupts the LVT (overlapping/wrong slots) so JDWP shows garbage.
- **#721:** `visitFrame` no longer replaces expanded frames with stale method-entry `implicitFrameLocals`. That dropped in-method updates when a parameter slot is overwritten with another reference type (ServletContextListener-style), producing `VerifyError` on exception handlers.
- **#883** (EJB default methods) is **out of scope** — needs a minimal EAR repro; tracked separately.

## Test plan
- [x] `mvn test -Dtest=WeaverTest -pl :glowroot-agent-core-unshaded` (117 tests)
- [x] New: no `glowroot$*` names in LVT after weave
- [x] New: weave method that overwrites param slot + try/catch (no VerifyError)
