### PR TITLE
Embedded scale stress harness + H2 index/SQL hardening

### DIFF
--- a/agent/benchmarks/src/main/java/org/glowroot/microbenchmarks/AgentQueuePressureBenchmark.java
+++ b/agent/benchmarks/src/main/java/org/glowroot/microbenchmarks/AgentQueuePressureBenchmark.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.microbenchmarks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Threads(8)
+@State(Scope.Benchmark)
+public class AgentQueuePressureBenchmark {
+
+    @Param({"0", "64"})
+    private int retainOpen;
+
+    private final List<Thread> holders = new ArrayList<Thread>();
+    private CountDownLatch release;
+
+    @Setup(Level.Trial)
+    public void setupHolders() throws InterruptedException {
+        release = new CountDownLatch(1);
+        CountDownLatch started = new CountDownLatch(retainOpen);
+        for (int i = 0; i < retainOpen; i++) {
+            Thread t = new Thread(new Holder(release, started), "queue-holder-" + i);
+            t.setDaemon(true);
+            holders.add(t);
+            t.start();
+        }
+        if (retainOpen > 0 && !started.await(30, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("retain holders did not start in time");
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDownHolders() throws InterruptedException {
+        release.countDown();
+        for (Thread t : holders) {
+            t.join(5000);
+        }
+        holders.clear();
+    }
+
+    @Benchmark
+    public void execute() {
+        churnTransaction();
+    }
+
+    // woven via META-INF/glowroot.plugin.json capturePoints
+    public void churnTransaction() {}
+
+    // woven via META-INF/glowroot.plugin.json capturePoints
+    public static void retainTransaction(CountDownLatch release, CountDownLatch started)
+            throws InterruptedException {
+        started.countDown();
+        release.await();
+    }
+
+    private static class Holder implements Runnable {
+        private final CountDownLatch release;
+        private final CountDownLatch started;
+
+        private Holder(CountDownLatch release, CountDownLatch started) {
+            this.release = release;
+            this.started = started;
+        }
+
+        @Override
+        public void run() {
+            try {
+                retainTransaction(release, started);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/agent/benchmarks/src/main/java/org/glowroot/microbenchmarks/JdbcMemoryPressureBenchmark.java
+++ b/agent/benchmarks/src/main/java/org/glowroot/microbenchmarks/JdbcMemoryPressureBenchmark.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.microbenchmarks;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(jvmArgsAppend = "-Xmx256m")
+@State(Scope.Thread)
+public class JdbcMemoryPressureBenchmark {
+
+    @Param({"0", "262144", "2097152"})
+    private int allocBytes;
+
+    private Connection connection;
+    private PreparedStatement preparedStatement;
+
+    @Setup
+    public void setup() throws SQLException {
+        connection = DriverManager.getConnection("jdbc:hsqldb:mem:jdbc_mem_pressure", "sa", "");
+        Statement statement = connection.createStatement();
+        try {
+            statement.execute("create table mock (name varchar(100))");
+            for (int i = 0; i < 1000; i++) {
+                statement.execute("insert into mock (name) values ('mock" + i + "')");
+            }
+        } finally {
+            statement.close();
+        }
+        preparedStatement = connection.prepareStatement("select * from mock");
+    }
+
+    @TearDown
+    public void tearDown() throws SQLException {
+        preparedStatement.close();
+        connection.close();
+    }
+
+    @Benchmark
+    public int execute() throws Exception {
+        return queryUnderTransaction();
+    }
+
+    // woven via META-INF/glowroot.plugin.json capturePoints
+    public int queryUnderTransaction() throws SQLException {
+        byte[] pressure = allocBytes == 0 ? null : new byte[allocBytes];
+        int rows = 0;
+        ResultSet resultSet = preparedStatement.executeQuery();
+        try {
+            while (resultSet.next()) {
+                rows++;
+            }
+        } finally {
+            resultSet.close();
+        }
+        return rows + (pressure == null ? 0 : pressure.length);
+    }
+}

--- a/agent/benchmarks/src/main/java/org/glowroot/microbenchmarks/support/TimerWorthyAspect.java
+++ b/agent/benchmarks/src/main/java/org/glowroot/microbenchmarks/support/TimerWorthyAspect.java
@@ -26,7 +26,7 @@ import org.glowroot.agent.plugin.api.weaving.Pointcut;
 
 public class TimerWorthyAspect {
 
-    @Pointcut(className = "org.glowroot.microbenchmarks.core.support.TimerWorthy",
+    @Pointcut(className = "org.glowroot.microbenchmarks.support.TimerWorthy",
             methodName = "doSomethingTimerWorthy", methodParameterTypes = {},
             timerName = "timer worthy")
     public static class TimerWorthyAdvice {
@@ -44,7 +44,7 @@ public class TimerWorthyAspect {
         }
     }
 
-    @Pointcut(className = "org.glowroot.microbenchmarks.core.support.TimerWorthy",
+    @Pointcut(className = "org.glowroot.microbenchmarks.support.TimerWorthy",
             methodName = "doSomethingTimerWorthyB", methodParameterTypes = {},
             timerName = "timer worthy B")
     public static class TimerWorthyAdviceB {

--- a/agent/benchmarks/src/main/java/org/glowroot/microbenchmarks/support/TraceEntryWorthyAspect.java
+++ b/agent/benchmarks/src/main/java/org/glowroot/microbenchmarks/support/TraceEntryWorthyAspect.java
@@ -29,7 +29,7 @@ import org.glowroot.agent.plugin.api.weaving.Pointcut;
 
 public class TraceEntryWorthyAspect {
 
-    @Pointcut(className = "org.glowroot.microbenchmarks.core.support.TraceEntryWorthy",
+    @Pointcut(className = "org.glowroot.microbenchmarks.support.TraceEntryWorthy",
             methodName = "doSomethingTraceEntryWorthy", methodParameterTypes = {},
             timerName = "trace entry worthy")
     public static class TraceEntryWorthyAdvice {

--- a/agent/benchmarks/src/main/java/org/glowroot/microbenchmarks/support/TransactionWorthyAspect.java
+++ b/agent/benchmarks/src/main/java/org/glowroot/microbenchmarks/support/TransactionWorthyAspect.java
@@ -29,7 +29,7 @@ import org.glowroot.agent.plugin.api.weaving.Pointcut;
 
 public class TransactionWorthyAspect {
 
-    @Pointcut(className = "org.glowroot.microbenchmarks.core.support.TransactionWorthy",
+    @Pointcut(className = "org.glowroot.microbenchmarks.support.TransactionWorthy",
             methodName = "doSomethingTransactionWorthy", methodParameterTypes = {},
             timerName = "transaction worthy")
     public static class TransactionWorthyAdvice {

--- a/agent/benchmarks/src/main/resources/META-INF/glowroot.plugin.json
+++ b/agent/benchmarks/src/main/resources/META-INF/glowroot.plugin.json
@@ -1,17 +1,18 @@
 {
   "name": "Microbenchmarks Plugin",
   "id": "glowroot-microbenchmarks",
-  "capturePoints": [
+  "instrumentation": [
     {
-      "className": "org.glowroot.microbenchmarks.core.support.TransactionWorthy",
+      "className": "org.glowroot.microbenchmarks.support.TransactionWorthy",
       "methodName": "doSomethingTransactionWorthy2",
       "methodParameterTypes": [ ],
       "captureKind": "transaction",
+      "transactionType": "Microbenchmark",
       "transactionNameTemplate": "transaction worthy",
       "timerName": "transaction worthy"
     },
     {
-      "className": "org.glowroot.microbenchmarks.core.support.TraceEntryWorthy",
+      "className": "org.glowroot.microbenchmarks.support.TraceEntryWorthy",
       "methodName": "doSomethingTraceEntryWorthy2",
       "methodParameterTypes": [ ],
       "captureKind": "trace-entry",
@@ -19,23 +20,53 @@
       "traceEntryMessageTemplate": "trace entry worthy: {{this.name}}"
     },
     {
-      "className": "org.glowroot.microbenchmarks.core.support.TimerWorthy",
+      "className": "org.glowroot.microbenchmarks.support.TimerWorthy",
       "methodName": "doSomethingTimerWorthy2",
       "methodParameterTypes": [ ],
       "captureKind": "timer",
       "timerName": "timer worthy"
     },
     {
-      "className": "org.glowroot.microbenchmarks.core.support.TimerWorthy",
+      "className": "org.glowroot.microbenchmarks.support.TimerWorthy",
       "methodName": "doSomethingTimerWorthy2B",
       "methodParameterTypes": [ ],
       "captureKind": "timer",
       "timerName": "timer worthy B"
+    },
+    {
+      "className": "org.glowroot.microbenchmarks.JdbcMemoryPressureBenchmark",
+      "methodName": "queryUnderTransaction",
+      "methodParameterTypes": [ ],
+      "captureKind": "transaction",
+      "transactionType": "Microbenchmark",
+      "transactionNameTemplate": "jdbc memory pressure",
+      "timerName": "jdbc memory pressure"
+    },
+    {
+      "className": "org.glowroot.microbenchmarks.AgentQueuePressureBenchmark",
+      "methodName": "churnTransaction",
+      "methodParameterTypes": [ ],
+      "captureKind": "transaction",
+      "transactionType": "Microbenchmark",
+      "transactionNameTemplate": "queue churn",
+      "timerName": "queue churn"
+    },
+    {
+      "className": "org.glowroot.microbenchmarks.AgentQueuePressureBenchmark",
+      "methodName": "retainTransaction",
+      "methodParameterTypes": [
+        "java.util.concurrent.CountDownLatch",
+        "java.util.concurrent.CountDownLatch"
+      ],
+      "captureKind": "transaction",
+      "transactionType": "Microbenchmark",
+      "transactionNameTemplate": "queue retain",
+      "timerName": "queue retain"
     }
   ],
   "aspects": [
-    "org.glowroot.microbenchmarks.core.support.TransactionWorthyAspect",
-    "org.glowroot.microbenchmarks.core.support.TraceEntryWorthyAspect",
-    "org.glowroot.microbenchmarks.core.support.TimerWorthyAspect"
+    "org.glowroot.microbenchmarks.support.TransactionWorthyAspect",
+    "org.glowroot.microbenchmarks.support.TraceEntryWorthyAspect",
+    "org.glowroot.microbenchmarks.support.TimerWorthyAspect"
   ]
 }

--- a/agent/embedded/src/main/java/org/glowroot/agent/embedded/repo/AggregateDao.java
+++ b/agent/embedded/src/main/java/org/glowroot/agent/embedded/repo/AggregateDao.java
@@ -135,23 +135,27 @@ public class AggregateDao implements AggregateRepository {
                     ImmutableColumn.of("async_timers", ColumnType.VARBINARY), // protobuf
                     ImmutableColumn.of("duration_nanos_histogram", ColumnType.VARBINARY)); // protobuf
 
-    // this index includes all columns needed for the overall aggregate query so h2 can return
-    // the result set directly from the index without having to reference the table for each row
+    // Index columns for summary aggregates (OverallSummaryQuery / TransactionNameSummaryQuery)
+    // and CappedIdQuery (/queries, /service-calls, profiles). Not sufficient alone for overview /
+    // percentile SELECTs that also read timers, histograms, async_transactions, etc.
+    // (capped_id columns included so CappedIdQuery can be index-friendly)
     private static final ImmutableList<String> overallAggregateIndexColumns =
             ImmutableList.of("capture_time", "transaction_type", "total_duration_nanos",
                     "transaction_count", "error_count",
                     "main_thread_total_cpu_nanos", "aux_thread_total_cpu_nanos",
-                    "main_thread_total_allocated_bytes", "aux_thread_total_allocated_bytes");
+                    "main_thread_total_allocated_bytes", "aux_thread_total_allocated_bytes",
+                    "queries_capped_id", "service_calls_capped_id",
+                    "main_thread_profile_capped_id", "aux_thread_profile_capped_id");
 
-    // this index includes all columns needed for the transaction aggregate query so h2 can return
-    // the result set directly from the index without having to reference the table for each row
-    //
-    // capture_time is first so this can also be used for readTransactionErrorCounts()
+    // Same idea for per-transaction-name rollups. capture_time is first so time-range scans
+    // (including TransactionNameErrorSummaryQuery) can use the index prefix.
     private static final ImmutableList<String> transactionAggregateIndexColumns =
             ImmutableList.of("capture_time", "transaction_type", "transaction_name",
                     "total_duration_nanos", "transaction_count", "error_count",
                     "main_thread_total_cpu_nanos", "aux_thread_total_cpu_nanos",
-                    "main_thread_total_allocated_bytes", "aux_thread_total_allocated_bytes");
+                    "main_thread_total_allocated_bytes", "aux_thread_total_allocated_bytes",
+                    "queries_capped_id", "service_calls_capped_id",
+                    "main_thread_profile_capped_id", "aux_thread_profile_capped_id");
 
     private final DataSource dataSource;
     private final List<CappedDatabase> rollupCappedDatabases;

--- a/agent/embedded/src/main/java/org/glowroot/agent/embedded/repo/FullQueryTextDao.java
+++ b/agent/embedded/src/main/java/org/glowroot/agent/embedded/repo/FullQueryTextDao.java
@@ -46,7 +46,11 @@ class FullQueryTextDao {
             ImmutableColumn.of("last_capture_time", ColumnType.BIGINT));
 
     private static final ImmutableList<Index> indexes = ImmutableList.<Index>of(
-            ImmutableIndex.of("full_query_text_idx", ImmutableList.of("full_text_sha1")),
+            ImmutableIndex.builder()
+                    .name("full_query_text_idx")
+                    .addColumns("full_text_sha1")
+                    .unique(true)
+                    .build(),
             // full_query_text_last_capture_time_idx is for reaper, this is very important when
             // full query text table is large
             ImmutableIndex.of("full_query_text_last_capture_time_idx",

--- a/agent/embedded/src/main/java/org/glowroot/agent/embedded/repo/TraceDao.java
+++ b/agent/embedded/src/main/java/org/glowroot/agent/embedded/repo/TraceDao.java
@@ -104,8 +104,8 @@ public class TraceDao implements TraceRepository {
                     ImmutableColumn.of("capture_time", ColumnType.BIGINT));
 
     private static final ImmutableList<Index> traceIndexes = ImmutableList.<Index>of(
-            // duration_nanos, id and error columns are included so database can return the
-            // result set directly from the index without having to reference the table for each row
+            // duration_nanos / error / id support covering reads for point listings; SELECT also
+            // needs partial (not indexed) so H2 still touches the table for that column
             //
             // trace_overall_slow_idx is for readSlowCount() and readSlowPoints()
             ImmutableIndex.of("trace_overall_slow_idx",
@@ -115,7 +115,7 @@ public class TraceDao implements TraceRepository {
             ImmutableIndex.of("trace_transaction_slow_idx",
                     ImmutableList.of("transaction_type", "transaction_name", "slow", "capture_time",
                             "duration_nanos", "error", "id")),
-            // trace_overall_error_idx is for readErrorCount() and readErrorPoints()
+            // trace_error_idx is for readErrorCount() and readErrorPoints()
             ImmutableIndex.of("trace_error_idx",
                     ImmutableList.of("transaction_type", "error", "capture_time", "duration_nanos",
                             "error", "id")),
@@ -123,6 +123,13 @@ public class TraceDao implements TraceRepository {
             ImmutableIndex.of("trace_transaction_error_idx",
                     ImmutableList.of("transaction_type", "transaction_name", "error",
                             "capture_time", "duration_nanos", "id")),
+            // covering-ish for ErrorMessageCountQuery (GROUP BY error_message) and error-message
+            // filters on ErrorPointQuery. Kept separate so point queries retain leaner indexes.
+            ImmutableIndex.of("trace_error_message_idx",
+                    ImmutableList.of("transaction_type", "error", "capture_time", "error_message")),
+            ImmutableIndex.of("trace_transaction_error_message_idx",
+                    ImmutableList.of("transaction_type", "transaction_name", "error", "capture_time",
+                            "error_message")),
             // trace_capture_time_idx is for reaper, this is very important when trace table is huge
             // e.g. after leaving slow threshold at 0 for a while
             ImmutableIndex.of("trace_capture_time_idx", ImmutableList.of("capture_time")),

--- a/agent/embedded/src/main/java/org/glowroot/agent/embedded/repo/TracePointQueryBuilder.java
+++ b/agent/embedded/src/main/java/org/glowroot/agent/embedded/repo/TracePointQueryBuilder.java
@@ -166,10 +166,13 @@ class TracePointQueryBuilder {
     }
 
     private void appendOrderByAndLimit(ParameterizedSqlBuilder builder) {
-        builder.appendText(" order by trace.duration_nanos");
+        // Slow/error indexes are (... capture_time, duration_nanos, ...). A capture_time range
+        // is therefore not ordered by duration_nanos, so wide windows still need a top-N sort.
+        // Keep ORDER BY on columns present in those indexes; id breaks ties stably.
+        builder.appendText(" order by trace.duration_nanos desc, trace.capture_time desc, trace.id");
         if (limit != 0) {
             // +1 is to identify if limit was exceeded
-            builder.appendText(" desc limit ?");
+            builder.appendText(" limit ?");
             builder.addArg(limit + 1);
         }
     }

--- a/agent/embedded/src/main/java/org/glowroot/agent/embedded/util/DataSource.java
+++ b/agent/embedded/src/main/java/org/glowroot/agent/embedded/util/DataSource.java
@@ -16,6 +16,8 @@
 package org.glowroot.agent.embedded.util;
 
 import java.io.File;
+import java.io.Flushable;
+import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -59,6 +61,8 @@ import static org.glowroot.agent.util.Checkers.castUntainted;
 public class DataSource {
 
     private static final Logger logger = LoggerFactory.getLogger(DataSource.class);
+
+    private static final @Nullable Appendable H2_TIMING_LOG = openH2TimingLog();
 
     private static final int QUERY_TIMEOUT_SECONDS =
             Integer.getInteger("glowroot.internal.h2.queryTimeout", 60);
@@ -224,7 +228,18 @@ public class DataSource {
             try {
                 // setQueryTimeout() affects all statements of this connection (at least with h2)
                 statement.setQueryTimeout(0);
-                statement.execute(sql);
+                long startNanos = 0;
+                boolean timing = H2_TIMING_LOG != null;
+                if (timing) {
+                    startNanos = System.nanoTime();
+                }
+                try {
+                    statement.execute(sql);
+                } finally {
+                    if (timing) {
+                        recordH2Timing(sql, startNanos);
+                    }
+                }
             } catch (Throwable t) {
                 throw closer.rethrow(t);
             } finally {
@@ -309,7 +324,19 @@ public class DataSource {
             PreparedStatement preparedStatement =
                     prepareStatementUnderLock(jdbcQuery.getSql(), QUERY_TIMEOUT_SECONDS);
             jdbcQuery.bind(preparedStatement);
-            ResultSet resultSet = preparedStatement.executeQuery();
+            long startNanos = 0;
+            boolean timing = H2_TIMING_LOG != null;
+            if (timing) {
+                startNanos = System.nanoTime();
+            }
+            ResultSet resultSet;
+            try {
+                resultSet = preparedStatement.executeQuery();
+            } finally {
+                if (timing) {
+                    recordH2Timing(jdbcQuery.getSql(), startNanos);
+                }
+            }
             ResultSetCloser closer = new ResultSetCloser(resultSet);
             try {
                 return jdbcQuery.processResultSet(resultSet);
@@ -344,7 +371,19 @@ public class DataSource {
             PreparedStatement preparedStatement =
                     prepareStatementUnderLock(jdbcQuery.getSql(), QUERY_TIMEOUT_SECONDS);
             jdbcQuery.bind(preparedStatement);
-            ResultSet resultSet = preparedStatement.executeQuery();
+            long startNanos = 0;
+            boolean timing = H2_TIMING_LOG != null;
+            if (timing) {
+                startNanos = System.nanoTime();
+            }
+            ResultSet resultSet;
+            try {
+                resultSet = preparedStatement.executeQuery();
+            } finally {
+                if (timing) {
+                    recordH2Timing(jdbcQuery.getSql(), startNanos);
+                }
+            }
             ResultSetCloser closer = new ResultSetCloser(resultSet);
             try {
                 List<T> mappedRows = Lists.newArrayList();
@@ -391,7 +430,18 @@ public class DataSource {
             checkConnectionUnderLock();
             PreparedStatement preparedStatement = prepareStatementUnderLock(jdbcUpdate.getSql(), 0);
             jdbcUpdate.bind(preparedStatement);
-            return preparedStatement.executeUpdate();
+            long startNanos = 0;
+            boolean timing = H2_TIMING_LOG != null;
+            if (timing) {
+                startNanos = System.nanoTime();
+            }
+            try {
+                return preparedStatement.executeUpdate();
+            } finally {
+                if (timing) {
+                    recordH2Timing(jdbcUpdate.getSql(), startNanos);
+                }
+            }
             // don't need to close statement since they are all cached and used under lock
         }
     }
@@ -410,7 +460,18 @@ public class DataSource {
             checkConnectionUnderLock();
             PreparedStatement preparedStatement = prepareStatementUnderLock(jdbcUpdate.getSql(), 0);
             jdbcUpdate.bind(preparedStatement);
-            return preparedStatement.executeBatch();
+            long startNanos = 0;
+            boolean timing = H2_TIMING_LOG != null;
+            if (timing) {
+                startNanos = System.nanoTime();
+            }
+            try {
+                return preparedStatement.executeBatch();
+            } finally {
+                if (timing) {
+                    recordH2Timing(jdbcUpdate.getSql(), startNanos);
+                }
+            }
             // don't need to close statement since they are all cached and used under lock
         }
     }
@@ -582,7 +643,19 @@ public class DataSource {
         for (int i = 0; i < args.length; i++) {
             preparedStatement.setObject(i + 1, args[i]);
         }
-        ResultSet resultSet = preparedStatement.executeQuery();
+        long startNanos = 0;
+        boolean timing = H2_TIMING_LOG != null;
+        if (timing) {
+            startNanos = System.nanoTime();
+        }
+        ResultSet resultSet;
+        try {
+            resultSet = preparedStatement.executeQuery();
+        } finally {
+            if (timing) {
+                recordH2Timing(sql, startNanos);
+            }
+        }
         return extractAndClose(resultSet, rse);
         // don't need to close statement since they are all cached and used under lock
     }
@@ -637,6 +710,49 @@ public class DataSource {
     private static int resolveInitialCacheSizeKb() {
         return H2CacheSize.resolveKb(H2CacheSize.MODE_AUTO, H2CacheSize.AUTO_MB,
                 Runtime.getRuntime().maxMemory(), System.getProperty(H2CacheSize.SYSTEM_PROPERTY));
+    }
+
+    private static @Nullable Appendable openH2TimingLog() {
+        String path = System.getProperty("glowroot.internal.h2.timingLog");
+        if (path == null || path.isEmpty()) {
+            return null;
+        }
+        try {
+            File file = new File(path);
+            File parent = file.getParentFile();
+            if (parent != null) {
+                parent.mkdirs();
+            }
+            return new java.io.FileWriter(file, true);
+        } catch (IOException e) {
+            logger.warn("could not open glowroot.internal.h2.timingLog: {}", path, e);
+            return null;
+        }
+    }
+
+    private static void recordH2Timing(@Nullable String sql, long startNanos) {
+        Appendable log = H2_TIMING_LOG;
+        if (log == null) {
+            return;
+        }
+        long milliseconds = (System.nanoTime() - startNanos) / 1000000L;
+        String truncatedSql = sql == null ? ""
+                : sql.replace('\r', ' ').replace('\n', ' ').replace(',', ';');
+        if (truncatedSql.length() > 200) {
+            truncatedSql = truncatedSql.substring(0, 200);
+        }
+        try {
+            synchronized (DataSource.class) {
+                log.append(Long.toString(System.currentTimeMillis())).append(',')
+                        .append(Long.toString(milliseconds)).append(',')
+                        .append(truncatedSql).append('\n');
+                if (log instanceof Flushable) {
+                    ((Flushable) log).flush();
+                }
+            }
+        } catch (IOException e) {
+            logger.debug(e.getMessage(), e);
+        }
     }
 
     private static Connection createConnection(@Nullable File dbFile, int cacheSizeKb)

--- a/agent/embedded/src/main/java/org/glowroot/agent/embedded/util/Schemas.java
+++ b/agent/embedded/src/main/java/org/glowroot/agent/embedded/util/Schemas.java
@@ -208,6 +208,7 @@ public class Schemas {
             throws SQLException {
         ListMultimap</*@Untainted*/ String, /*@Untainted*/ String> indexColumns =
                 ArrayListMultimap.create();
+        Map</*@Untainted*/ String, Boolean> indexUnique = Maps.newHashMap();
         ResultSet resultSet = getMetaDataIndexInfo(connection, tableName);
         ResultSetCloser closer = new ResultSetCloser(resultSet);
         try {
@@ -217,7 +218,10 @@ public class Schemas {
                 // hack-ish to skip over primary key constraints which seem to be always
                 // prefixed in H2 by PRIMARY_KEY_
                 if (!indexName.startsWith("PRIMARY_KEY_")) {
-                    indexColumns.put(castUntainted(indexName), castUntainted(columnName));
+                    String key = castUntainted(indexName);
+                    indexColumns.put(key, castUntainted(columnName));
+                    // NON_UNIQUE is false for unique indexes
+                    indexUnique.put(key, !resultSet.getBoolean("NON_UNIQUE"));
                 }
             }
         } catch (Throwable t) {
@@ -233,7 +237,12 @@ public class Schemas {
             for (String column : entry.getValue()) {
                 columns.add(column.toLowerCase(Locale.ENGLISH));
             }
-            indexes.add(ImmutableIndex.of(name, columns));
+            boolean unique = Boolean.TRUE.equals(indexUnique.get(entry.getKey()));
+            indexes.add(ImmutableIndex.builder()
+                    .name(name)
+                    .columns(columns)
+                    .unique(unique)
+                    .build());
         }
         return indexes.build();
     }
@@ -241,7 +250,7 @@ public class Schemas {
     private static void createIndex(String tableName, Index index, Connection connection)
             throws SQLException {
         StringBuilder sql = new StringBuilder();
-        sql.append("create index ");
+        sql.append(index.unique() ? "create unique index " : "create index ");
         sql.append(index.name());
         sql.append(" on ");
         sql.append(tableName);
@@ -308,10 +317,15 @@ public class Schemas {
     }
 
     @Value.Immutable
-    @Styles.AllParameters
     public interface Index {
+        @Value.Parameter
         @Untainted
         String name();
+        @Value.Parameter
         ImmutableList</*@Untainted*/ String> columns();
+        @Value.Default
+        default boolean unique() {
+            return false;
+        }
     }
 }

--- a/agent/embedded/src/test/java/org/glowroot/agent/embedded/util/SchemasTest.java
+++ b/agent/embedded/src/test/java/org/glowroot/agent/embedded/util/SchemasTest.java
@@ -44,4 +44,25 @@ public class SchemasTest {
         assertThat(indexes.iterator().next())
                 .isEqualTo(ImmutableIndex.of("tab_idx", ImmutableList.of("a")));
     }
+
+    @Test
+    public void shouldSyncUniqueIndex() throws Exception {
+        Connection connection =
+                DriverManager.getConnection("jdbc:h2:mem:;NON_KEYWORDS=USER,VALUE");
+        Statement statement = connection.createStatement();
+        statement.execute("create table tab (a varchar, b bigint)");
+        Schemas.syncIndexes("tab",
+                ImmutableList.of(ImmutableIndex.builder()
+                        .name("tab_uidx")
+                        .addColumns("a")
+                        .unique(true)
+                        .build()),
+                connection);
+        Set<Index> indexes = Schemas.getIndexes("tab", connection);
+        assertThat(indexes).hasSize(1);
+        Index index = indexes.iterator().next();
+        assertThat(index.name()).isEqualTo("tab_uidx");
+        assertThat(index.columns()).containsExactly("a");
+        assertThat(index.unique()).isTrue();
+    }
 }

--- a/agent/stress/pom.xml
+++ b/agent/stress/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.glowroot</groupId>
+    <artifactId>glowroot-parent</artifactId>
+    <version>0.14.8-beta.5-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>glowroot-agent-stress</artifactId>
+
+  <name>Glowroot Agent Stress</name>
+  <description>Long-running agent stress harness with optional JDBC and memory pressure</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <version>2.5.2</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>org.glowroot.agent.stress.StressMain</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>stress</finalName>
+              <transformers>
+                <transformer
+                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.glowroot.agent.stress.StressMain</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/agent/stress/src/main/java/org/glowroot/agent/stress/CompareReport.java
+++ b/agent/stress/src/main/java/org/glowroot/agent/stress/CompareReport.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.stress;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeSet;
+
+/**
+ * Produces a markdown comparison of two embedded-scale stress runs.
+ */
+public class CompareReport {
+
+    public static void main(String[] args) throws Exception {
+        Options options = Options.parse(args);
+        Run a = readRun(options.a);
+        Run b = readRun(options.b);
+        File parent = options.out.getParentFile();
+        if (parent != null) {
+            parent.mkdirs();
+        }
+        Files.write(options.out.toPath(), writeReport(a, b).getBytes(StandardCharsets.UTF_8));
+        System.out.println("wrote " + options.out);
+    }
+
+    private static Run readRun(File dir) throws IOException {
+        FillProgress.Snapshot progress = FillProgress.readOrNull(new File(dir, "fill-progress.json"));
+        if (progress == null) {
+            throw new IllegalArgumentException("missing fill-progress.json: " + dir);
+        }
+        return new Run(dir.getName(), progress, readHttp(new File(dir, "timing-http.csv")),
+                readH2(new File(dir, "timing-h2.csv")), readLines(new File(dir, "events.log")));
+    }
+
+    private static String writeReport(Run a, Run b) {
+        StringBuilder report = new StringBuilder();
+        report.append("# Embedded-scale comparison\n\n");
+        report.append("## Fill\n\n");
+        report.append("| Run | Data (GiB) | Target (GiB) | Ops | Updated |\n");
+        report.append("| --- | ---: | ---: | ---: | --- |\n");
+        appendFill(report, a);
+        appendFill(report, b);
+        report.append("\nWall time is n/a: `fill-progress.json` records only its final update time.\n\n");
+
+        report.append("## Dual HTTP\n\n");
+        report.append("| Endpoint | ").append(a.name).append(" p50 (ms) | ").append(a.name)
+                .append(" p99 (ms) | n | ").append(b.name).append(" p50 (ms) | ").append(b.name)
+                .append(" p99 (ms) | n |\n");
+        report.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: |\n");
+        TreeSet<String> endpoints = new TreeSet<String>();
+        endpoints.addAll(a.http.keySet());
+        endpoints.addAll(b.http.keySet());
+        if (endpoints.isEmpty()) {
+            report.append("| n/a | - | - | 0 | - | - | 0 |\n");
+        } else {
+            for (String endpoint : endpoints) {
+                report.append("| ").append(endpoint).append(" | ");
+                appendHttpStats(report, a.http.get(endpoint));
+                report.append(" | ");
+                appendHttpStats(report, b.http.get(endpoint));
+                report.append(" |\n");
+            }
+        }
+
+        report.append("\n## H2\n\n");
+        appendH2(report, a);
+        appendH2(report, b);
+
+        report.append("\n## Events\n\n");
+        appendEvents(report, a);
+        appendEvents(report, b);
+        return report.toString();
+    }
+
+    private static void appendFill(StringBuilder report, Run run) {
+        FillProgress.Snapshot progress = run.progress;
+        report.append("| ").append(run.name).append(" | ")
+                .append(String.format(Locale.US, "%.3f", progress.dataBytes / 1073741824.0))
+                .append(" | ").append(String.format(Locale.US, "%.3f", progress.targetGb)).append(" | ")
+                .append(progress.ops).append(" | ").append(progress.updatedAt).append(" |\n");
+    }
+
+    private static void appendHttpStats(StringBuilder report, List<Long> values) {
+        if (values == null || values.isEmpty()) {
+            report.append("- | - | 0");
+            return;
+        }
+        long[] sorted = sorted(values);
+        report.append(String.format(Locale.US, "%.1f", percentileMs(sorted, 0.50))).append(" | ")
+                .append(String.format(Locale.US, "%.1f", percentileMs(sorted, 0.99))).append(" | ")
+                .append(sorted.length);
+    }
+
+    private static void appendH2(StringBuilder report, Run run) {
+        report.append("### ").append(run.name).append("\n\n");
+        if (run.h2.isEmpty()) {
+            report.append("n/a\n\n");
+            return;
+        }
+        report.append("| Latency (ms) | SQL |\n| ---: | --- |\n");
+        int limit = Math.min(15, run.h2.size());
+        for (int i = 0; i < limit; i++) {
+            H2Line line = run.h2.get(i);
+            report.append("| ").append(line.latencyMs).append(" | ").append(line.sql).append(" |\n");
+        }
+        report.append('\n');
+    }
+
+    private static void appendEvents(StringBuilder report, Run run) {
+        report.append("### ").append(run.name).append("\n\n");
+        if (run.events.isEmpty()) {
+            report.append("n/a\n\n");
+            return;
+        }
+        for (String event : run.events) {
+            report.append("- ").append(event).append('\n');
+        }
+        report.append('\n');
+    }
+
+    private static Map<String, List<Long>> readHttp(File file) throws IOException {
+        Map<String, List<Long>> timings = new LinkedHashMap<String, List<Long>>();
+        for (String line : readLines(file)) {
+            String[] parts = line.split(",", 5);
+            if (parts.length != 5 || "ts".equals(parts[0]) || !parts[3].startsWith("2")) {
+                continue;
+            }
+            try {
+                List<Long> values = timings.get(parts[2]);
+                if (values == null) {
+                    values = new ArrayList<Long>();
+                    timings.put(parts[2], values);
+                }
+                values.add(Long.parseLong(parts[4]));
+            } catch (NumberFormatException e) {
+                // Ignore a partially-written or malformed timing row.
+            }
+        }
+        return timings;
+    }
+
+    private static List<H2Line> readH2(File file) throws IOException {
+        List<H2Line> lines = new ArrayList<H2Line>();
+        for (String line : readLines(file)) {
+            String[] parts = line.split(",", 3);
+            if (parts.length != 3 || "ts".equals(parts[0])) {
+                continue;
+            }
+            try {
+                lines.add(new H2Line(Long.parseLong(parts[1]), parts[2]));
+            } catch (NumberFormatException e) {
+                // Ignore a partially-written or malformed timing row.
+            }
+        }
+        Collections.sort(lines, new Comparator<H2Line>() {
+            @Override
+            public int compare(H2Line left, H2Line right) {
+                return Long.compare(right.latencyMs, left.latencyMs);
+            }
+        });
+        return lines;
+    }
+
+    private static List<String> readLines(File file) throws IOException {
+        return file.exists() ? Files.readAllLines(file.toPath(), StandardCharsets.UTF_8)
+                : Collections.<String>emptyList();
+    }
+
+    private static long[] sorted(List<Long> values) {
+        long[] sorted = new long[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            sorted[i] = values.get(i);
+        }
+        Arrays.sort(sorted);
+        return sorted;
+    }
+
+    private static double percentileMs(long[] sortedMillis, double p) {
+        int idx = Math.min(sortedMillis.length - 1, (int) Math.round(p * (sortedMillis.length - 1)));
+        return sortedMillis[idx];
+    }
+
+    private static class Run {
+        private final String name;
+        private final FillProgress.Snapshot progress;
+        private final Map<String, List<Long>> http;
+        private final List<H2Line> h2;
+        private final List<String> events;
+
+        private Run(String name, FillProgress.Snapshot progress, Map<String, List<Long>> http,
+                List<H2Line> h2, List<String> events) {
+            this.name = name;
+            this.progress = progress;
+            this.http = http;
+            this.h2 = h2;
+            this.events = events;
+        }
+    }
+
+    private static class H2Line {
+        private final long latencyMs;
+        private final String sql;
+
+        private H2Line(long latencyMs, String sql) {
+            this.latencyMs = latencyMs;
+            this.sql = sql;
+        }
+    }
+
+    private static class Options {
+        private final File a;
+        private final File b;
+        private final File out;
+
+        private Options(File a, File b, File out) {
+            this.a = a;
+            this.b = b;
+            this.out = out;
+        }
+
+        private static Options parse(String[] args) {
+            File a = null;
+            File b = null;
+            File out = null;
+            for (String arg : args) {
+                if (arg.startsWith("--a=")) {
+                    a = new File(arg.substring("--a=".length()));
+                } else if (arg.startsWith("--b=")) {
+                    b = new File(arg.substring("--b=".length()));
+                } else if (arg.startsWith("--out=")) {
+                    out = new File(arg.substring("--out=".length()));
+                } else {
+                    throw new IllegalArgumentException("unknown arg: " + arg);
+                }
+            }
+            if (a == null || b == null || out == null) {
+                throw new IllegalArgumentException("usage: CompareReport --a=DIR --b=DIR --out=FILE");
+            }
+            return new Options(a, b, out);
+        }
+    }
+}

--- a/agent/stress/src/main/java/org/glowroot/agent/stress/FillProgress.java
+++ b/agent/stress/src/main/java/org/glowroot/agent/stress/FillProgress.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.stress;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Locale;
+
+final class FillProgress {
+
+    static final class Snapshot {
+        final double targetGb;
+        final long dataBytes;
+        final long ops;
+        final long updatedAt;
+
+        Snapshot(double targetGb, long dataBytes, long ops, long updatedAt) {
+            this.targetGb = targetGb;
+            this.dataBytes = dataBytes;
+            this.ops = ops;
+            this.updatedAt = updatedAt;
+        }
+
+        boolean reachedTarget() {
+            return dataBytes >= (long) (targetGb * 1024L * 1024L * 1024L);
+        }
+    }
+
+    static long directorySizeBytes(File dir) {
+        if (dir == null || !dir.exists()) {
+            return 0L;
+        }
+        long total = 0L;
+        File[] kids = dir.listFiles();
+        if (kids == null) {
+            return 0L;
+        }
+        for (File f : kids) {
+            if (f.isDirectory()) {
+                total += directorySizeBytes(f);
+            } else {
+                total += f.length();
+            }
+        }
+        return total;
+    }
+
+    static void write(File progressFile, Snapshot snapshot) throws IOException {
+        File parent = progressFile.getParentFile();
+        if (parent != null) {
+            parent.mkdirs();
+        }
+        String json = String.format(Locale.US,
+                "{\"targetGb\":%.3f,\"dataBytes\":%d,\"ops\":%d,\"updatedAt\":%d}%n",
+                snapshot.targetGb, snapshot.dataBytes, snapshot.ops, snapshot.updatedAt);
+        try (FileWriter writer = new FileWriter(progressFile)) {
+            writer.write(json);
+        }
+    }
+
+    static Snapshot readOrNull(File progressFile) throws IOException {
+        if (!progressFile.exists()) {
+            return null;
+        }
+        String raw = new String(Files.readAllBytes(progressFile.toPath()), StandardCharsets.UTF_8).trim();
+        return new Snapshot(
+                parseDoubleField(raw, "targetGb"),
+                parseLongField(raw, "dataBytes"),
+                parseLongField(raw, "ops"),
+                parseLongField(raw, "updatedAt"));
+    }
+
+    private static double parseDoubleField(String json, String name) {
+        String key = "\"" + name + "\":";
+        int i = json.indexOf(key);
+        if (i < 0) {
+            return 0;
+        }
+        int start = i + key.length();
+        int end = start;
+        while (end < json.length() && "0123456789.+-eE".indexOf(json.charAt(end)) >= 0) {
+            end++;
+        }
+        return Double.parseDouble(json.substring(start, end));
+    }
+
+    private static long parseLongField(String json, String name) {
+        return (long) parseDoubleField(json, name);
+    }
+
+    private FillProgress() {}
+}

--- a/agent/stress/src/main/java/org/glowroot/agent/stress/QueryHarvester.java
+++ b/agent/stress/src/main/java/org/glowroot/agent/stress/QueryHarvester.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.stress;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class QueryHarvester implements Runnable {
+
+    private static final Pattern NAMED_TRACE_ID =
+            Pattern.compile("\"(?:trace-id|traceId)\"\\s*:\\s*\"([^\"]+)\"");
+    private static final Pattern POINT_TRACE_ID =
+            Pattern.compile("\\[\\s*[^,\\]]+\\s*,\\s*[^,\\]]+\\s*,\\s*\"[^\"]*\"\\s*,\\s*\"([^\"]+)\"");
+
+    private final String uiBase;
+    private final long periodMillis;
+    private final File timingFile;
+    private final File eventsFile;
+    private final String phase;
+    private final AtomicBoolean stop;
+    private final Set<String> missingEndpoints = new HashSet<String>();
+
+    QueryHarvester(String uiBase, long periodMillis, File timingFile, String phase) {
+        this(uiBase, periodMillis, timingFile, phase, new AtomicBoolean());
+    }
+
+    QueryHarvester(String uiBase, long periodMillis, File timingFile, String phase,
+            AtomicBoolean stop) {
+        this.uiBase = uiBase.endsWith("/")
+                ? uiBase.substring(0, uiBase.length() - 1)
+                : uiBase;
+        this.periodMillis = periodMillis;
+        this.timingFile = timingFile;
+        File parent = timingFile.getAbsoluteFile().getParentFile();
+        this.eventsFile = new File(parent, "events.log");
+        this.phase = phase;
+        this.stop = stop;
+    }
+
+    @Override
+    public void run() {
+        while (!stop.get() && !Thread.currentThread().isInterrupted()) {
+            harvestOnce();
+            try {
+                Thread.sleep(periodMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    void harvestOnce() {
+        long now = System.currentTimeMillis();
+        long from = now - 15 * 60 * 1000L;
+        String timeRange = "agent-rollup-id=&transaction-type=Stress&from=" + from + "&to=" + now;
+        get("/backend/transaction/throughput", timeRange);
+        get("/backend/transaction/average", timeRange);
+        get("/backend/transaction/summaries", timeRange + "&sort-order=total-time&limit=10");
+        // Query aggregates (includes slow/heavy SQL text) — important on a large H2 fill.
+        Response queries = get("/backend/transaction/queries", timeRange);
+        if (queries.status >= 200 && queries.status < 300 && queries.body.length() > 2) {
+            String sha1 = extractFullQueryTextSha1(queries.body);
+            if (sha1 != null) {
+                get("/backend/transaction/full-query-text",
+                        "agent-rollup-id=&full-text-sha1=" + sha1);
+            }
+        }
+        get("/backend/transaction/service-calls", timeRange);
+        Response points = get("/backend/transaction/points",
+                "agent-rollup-id=&transaction-type=Stress&transaction-name=&from=" + from + "&to="
+                        + now + "&duration-millis-low=0&headline-comparator=begins&headline="
+                        + "&error-message-comparator=begins&error-message=&user-comparator=begins"
+                        + "&user=&attribute-name=&attribute-value-comparator=begins"
+                        + "&attribute-value=&limit=10");
+        if (points.status >= 200 && points.status < 300) {
+            String traceId = extractTraceId(points.body);
+            if (traceId != null) {
+                get("/backend/trace/header", "agent-id=&trace-id=" + traceId);
+            }
+        }
+        get("/backend/jvm/gauges", "agent-rollup-id=&from=" + from + "&to=" + now);
+        get("/backend/jvm/environment", "agent-id=");
+    }
+
+    private static String extractFullQueryTextSha1(String body) {
+        Matcher m = Pattern.compile("\"fullQueryTextSha1\"\\s*:\\s*\"([^\"]+)\"").matcher(body);
+        return m.find() ? m.group(1) : null;
+    }
+
+    private Response get(String endpoint, String query) {
+        if (missingEndpoints.contains(endpoint)) {
+            return new Response(404, "");
+        }
+        long start = System.nanoTime();
+        HttpURLConnection connection = null;
+        int status = -1;
+        String body = "";
+        try {
+            connection = (HttpURLConnection) new URL(uiBase + endpoint + "?" + query).openConnection();
+            connection.setRequestMethod("GET");
+            connection.setConnectTimeout(10_000);
+            connection.setReadTimeout(30_000);
+            status = connection.getResponseCode();
+            if (status >= 200 && status < 300) {
+                body = readBody(connection);
+            }
+            if (status == 404) {
+                logMissingEndpoint(endpoint);
+            }
+            writeTiming(endpoint, Integer.toString(status), elapsedMillis(start));
+        } catch (Exception e) {
+            writeTiming(endpoint, "ERR", elapsedMillis(start));
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+        return new Response(status, body);
+    }
+
+    private String readBody(HttpURLConnection connection) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(),
+                "UTF-8"));
+        try {
+            StringBuilder body = new StringBuilder();
+            char[] buffer = new char[4096];
+            int length;
+            while ((length = reader.read(buffer)) != -1) {
+                body.append(buffer, 0, length);
+            }
+            return body.toString();
+        } finally {
+            reader.close();
+        }
+    }
+
+    private void writeTiming(String endpoint, String status, long latencyMillis) {
+        File parent = timingFile.getAbsoluteFile().getParentFile();
+        if (!parent.exists() && !parent.mkdirs()) {
+            System.err.println("WARN: unable to create timing directory: " + parent);
+            return;
+        }
+        try {
+            boolean writeHeader = !timingFile.exists() || timingFile.length() == 0;
+            FileWriter writer = new FileWriter(timingFile, true);
+            try {
+                if (writeHeader) {
+                    writer.write("ts,phase,endpoint,status,latencyMs\n");
+                }
+                writer.write(System.currentTimeMillis() + "," + phase + "," + endpoint + "," + status
+                        + "," + latencyMillis + "\n");
+            } finally {
+                writer.close();
+            }
+        } catch (IOException e) {
+            System.err.println("WARN: unable to write HTTP timing: " + e.getMessage());
+        }
+    }
+
+    private void logMissingEndpoint(String endpoint) {
+        if (!missingEndpoints.add(endpoint)) {
+            return;
+        }
+        try {
+            FileWriter writer = new FileWriter(eventsFile, true);
+            try {
+                writer.write("HTTP endpoint unavailable (404), skipping endpoint: " + endpoint + "\n");
+            } finally {
+                writer.close();
+            }
+        } catch (IOException e) {
+            System.err.println("WARN: unable to write events log: " + e.getMessage());
+        }
+    }
+
+    private static long elapsedMillis(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000L;
+    }
+
+    private static String extractTraceId(String pointsJson) {
+        Matcher matcher = NAMED_TRACE_ID.matcher(pointsJson);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        matcher = POINT_TRACE_ID.matcher(pointsJson);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
+    private static class Response {
+        private final int status;
+        private final String body;
+
+        private Response(int status, String body) {
+            this.status = status;
+            this.body = body;
+        }
+    }
+}

--- a/agent/stress/src/main/java/org/glowroot/agent/stress/StressMain.java
+++ b/agent/stress/src/main/java/org/glowroot/agent/stress/StressMain.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.stress;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Long-running stress harness. Run under {@code -javaagent:glowroot.jar} so capturePoints weave and
+ * the embedded UI can show transactions/queries.
+ *
+ * <pre>
+ * java -javaagent:PATH/glowroot.jar -Dglowroot.data.dir=local-env/stress-data
+ *   -Dglowroot.agent.port=4002 -jar agent/stress/target/stress.jar
+ *   --mode=jdbc-stress --duration=60s --threads=32 --alloc-kb=512
+ * </pre>
+ * <p>Data defaults next to {@code glowroot.jar}; use {@code glowroot.data.dir} (and optionally
+ * {@code tmp.dir}/{@code log.dir}) to isolate runs. There is no {@code glowroot.agent.dir}.
+ * Fill runs should pass {@code --data-dir=local-env/embedded-scale/<label>/data} so the size
+ * probe measures the agent's embedded data directory.
+ */
+public class StressMain {
+
+    public static void main(String[] args) throws Exception {
+        Options options = Options.parse(args);
+        System.out.println("stress phase=" + options.phase + " mode=" + options.mode + " duration="
+                + options.durationMillis
+                + "ms threads=" + options.threads + " allocKb=" + options.allocKb
+                + " retainOpen=" + options.retainOpen + " uniqueQuery=" + options.uniqueQuery);
+        System.out.println("UI: " + options.uiBase + " (requires -javaagent)");
+        if (options.phase == Phase.FILL && (!options.dataDir.exists() || !options.dataDir.isDirectory())) {
+            throw new IllegalArgumentException("fill requires --data-dir=.../data (agent writes there via"
+                    + " jar-home or -Dglowroot.data.dir): " + options.dataDir);
+        }
+
+        Workloads workloads = new Workloads();
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch started = new CountDownLatch(options.retainOpen);
+        List<Thread> holders = new ArrayList<Thread>();
+        AtomicBoolean harvesterStop = new AtomicBoolean();
+        Thread harvesterThread = null;
+        try {
+            if (options.phase == Phase.DUAL || options.phase == Phase.QUERY_ONLY) {
+                String phase = options.phase.name().toLowerCase().replace('_', '-');
+                harvesterThread = new Thread(new QueryHarvester(options.uiBase,
+                        options.harvesterPeriodMillis, options.httpTimingFile, phase, harvesterStop),
+                        "query-harvester");
+                harvesterThread.setDaemon(true);
+                harvesterThread.start();
+            }
+            if (options.phase != Phase.QUERY_ONLY) {
+                for (int i = 0; i < options.retainOpen; i++) {
+                    Thread t = new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                Workloads.retainOnce(release, started);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                        }
+                    }, "stress-retain-" + i);
+                    t.setDaemon(true);
+                    holders.add(t);
+                    t.start();
+                }
+            }
+            if (options.phase != Phase.QUERY_ONLY && options.retainOpen > 0
+                    && !started.await(30, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("retain holders failed to start");
+            }
+
+            long startMillis = System.currentTimeMillis();
+            FillProgress.Snapshot previous = options.phase == Phase.FILL
+                    ? FillProgress.readOrNull(options.progressFile)
+                    : null;
+            AtomicLong ops = new AtomicLong(previous == null ? 0L : previous.ops);
+            AtomicLong jdbcSequence = new AtomicLong();
+            AtomicLong errors = new AtomicLong();
+            AtomicBoolean fillStop = new AtomicBoolean();
+            List<Long> latenciesNanos = Collections.synchronizedList(new ArrayList<Long>());
+            ExecutorService pool = options.phase == Phase.QUERY_ONLY
+                    ? null
+                    : Executors.newFixedThreadPool(options.threads);
+            long deadline = System.currentTimeMillis() + options.durationMillis;
+            if (pool != null) {
+                for (int i = 0; i < options.threads; i++) {
+                    pool.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        while ((options.phase == Phase.FILL || System.currentTimeMillis() < deadline)
+                                && !fillStop.get()
+                                && !Thread.currentThread().isInterrupted()) {
+                            long start = System.nanoTime();
+                            try {
+                                if (options.mode == Mode.JDBC_STRESS) {
+                                    if (options.uniqueQuery) {
+                                        long salt = ThreadLocalRandom.current().nextLong();
+                                        switch ((int) (jdbcSequence.getAndIncrement() % 3)) {
+                                            case 0:
+                                                workloads.jdbcOnceA(options.allocKb, salt);
+                                                break;
+                                            case 1:
+                                                workloads.jdbcOnceB(options.allocKb, salt);
+                                                break;
+                                            default:
+                                                workloads.jdbcOnceC(options.allocKb, salt);
+                                                break;
+                                        }
+                                    } else {
+                                        workloads.jdbcOnce(options.allocKb);
+                                    }
+                                } else {
+                                    workloads.churnOnce(options.allocKb);
+                                }
+                                ops.incrementAndGet();
+                                if (latenciesNanos.size() < 200000) {
+                                    latenciesNanos.add(System.nanoTime() - start);
+                                }
+                            } catch (Throwable t) {
+                                errors.incrementAndGet();
+                            }
+                        }
+                    }
+                    });
+                }
+            }
+            if (options.phase == Phase.FILL) {
+                FillProgress.Snapshot snapshot = writeFillProgress(options, ops.get());
+                while (!snapshot.reachedTarget()) {
+                    Thread.sleep(30_000L);
+                    snapshot = writeFillProgress(options, ops.get());
+                }
+                fillStop.set(true);
+                pool.shutdownNow();
+                if (!pool.awaitTermination(30, TimeUnit.SECONDS)) {
+                    System.err.println("WARN: fill workers did not stop within 30 seconds");
+                }
+            } else if (pool != null) {
+                pool.shutdown();
+                long wait = options.durationMillis + 30_000L;
+                if (!pool.awaitTermination(wait, TimeUnit.MILLISECONDS)) {
+                    pool.shutdownNow();
+                }
+            } else {
+                Thread.sleep(options.durationMillis);
+            }
+
+            long elapsedMs = Math.max(1, System.currentTimeMillis() - startMillis);
+            double opsPerSec = ops.get() * 1000.0 / elapsedMs;
+            long[] sorted = toSortedArray(latenciesNanos);
+            System.out.println(String.format(
+                    "done ops=%d errors=%d ops/s=%.1f p50=%.1fus p99=%.1fus samples=%d",
+                    ops.get(), errors.get(), opsPerSec, percentileUs(sorted, 0.50),
+                    percentileUs(sorted, 0.99), sorted.length));
+        } finally {
+            harvesterStop.set(true);
+            if (harvesterThread != null) {
+                harvesterThread.interrupt();
+                harvesterThread.join(5000);
+            }
+            release.countDown();
+            for (Thread t : holders) {
+                t.join(5000);
+            }
+            workloads.close();
+        }
+    }
+
+    private static FillProgress.Snapshot writeFillProgress(Options options, long ops)
+            throws java.io.IOException {
+        long dataBytes = FillProgress.directorySizeBytes(options.dataDir);
+        FillProgress.Snapshot snapshot = new FillProgress.Snapshot(options.targetGb, dataBytes, ops,
+                System.currentTimeMillis());
+        FillProgress.write(options.progressFile, snapshot);
+        System.out.println(String.format("fill gb=%.3f ops=%d", dataBytes / (1024.0 * 1024.0 * 1024.0),
+                ops));
+        return snapshot;
+    }
+
+    private static long[] toSortedArray(List<Long> values) {
+        long[] arr = new long[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            arr[i] = values.get(i);
+        }
+        Arrays.sort(arr);
+        return arr;
+    }
+
+    private static double percentileUs(long[] sortedNanos, double p) {
+        if (sortedNanos.length == 0) {
+            return 0;
+        }
+        int idx = Math.min(sortedNanos.length - 1, (int) Math.round(p * (sortedNanos.length - 1)));
+        return sortedNanos[idx] / 1000.0;
+    }
+
+    enum Mode {
+        JDBC_STRESS, AGENT_CHURN
+    }
+
+    enum Phase {
+        FILL, DUAL, QUERY_ONLY, LEGACY
+    }
+
+    static final class Options {
+        final Mode mode;
+        final Phase phase;
+        final long durationMillis;
+        final int threads;
+        final int allocKb;
+        final boolean uniqueQuery;
+        final int retainOpen;
+        final double targetGb;
+        final File dataDir;
+        final File progressFile;
+        final File httpTimingFile;
+        final long harvesterPeriodMillis;
+        final String uiBase;
+
+        private Options(Mode mode, Phase phase, long durationMillis, int threads, int allocKb,
+                boolean uniqueQuery, int retainOpen, double targetGb, File dataDir, File progressFile,
+                File httpTimingFile, long harvesterPeriodMillis, String uiBase) {
+            this.mode = mode;
+            this.phase = phase;
+            this.durationMillis = durationMillis;
+            this.threads = threads;
+            this.allocKb = allocKb;
+            this.uniqueQuery = uniqueQuery;
+            this.retainOpen = retainOpen;
+            this.targetGb = targetGb;
+            this.dataDir = dataDir;
+            this.progressFile = progressFile;
+            this.httpTimingFile = httpTimingFile;
+            this.harvesterPeriodMillis = harvesterPeriodMillis;
+            this.uiBase = uiBase;
+        }
+
+        static Options parse(String[] args) {
+            Mode mode = Mode.JDBC_STRESS;
+            Phase phase = Phase.LEGACY;
+            long durationMillis = 60_000L;
+            int threads = 32;
+            int allocKb = 512;
+            Boolean uniqueQuery = null;
+            int retainOpen = 0;
+            double targetGb = 60;
+            File dataDir = null;
+            File progressFile = null;
+            File httpTimingFile = null;
+            long harvesterPeriodMillis = 2000L;
+            String uiBase = null;
+            boolean durationSpecified = false;
+            for (int i = 0; i < args.length; i++) {
+                String a = args[i];
+                if (a.startsWith("--mode=")) {
+                    mode = parseMode(a.substring("--mode=".length()));
+                } else if (a.equals("--mode") && i + 1 < args.length) {
+                    mode = parseMode(args[++i]);
+                } else if (a.startsWith("--phase=")) {
+                    phase = parsePhase(a.substring("--phase=".length()));
+                } else if (a.equals("--phase") && i + 1 < args.length) {
+                    phase = parsePhase(args[++i]);
+                } else if (a.startsWith("--duration=")) {
+                    durationMillis = parseDurationMillis(a.substring("--duration=".length()));
+                    durationSpecified = true;
+                } else if (a.equals("--duration") && i + 1 < args.length) {
+                    durationMillis = parseDurationMillis(args[++i]);
+                    durationSpecified = true;
+                } else if (a.startsWith("--threads=")) {
+                    threads = Integer.parseInt(a.substring("--threads=".length()));
+                } else if (a.equals("--threads") && i + 1 < args.length) {
+                    threads = Integer.parseInt(args[++i]);
+                } else if (a.startsWith("--alloc-kb=")) {
+                    allocKb = Integer.parseInt(a.substring("--alloc-kb=".length()));
+                } else if (a.equals("--alloc-kb") && i + 1 < args.length) {
+                    allocKb = Integer.parseInt(args[++i]);
+                } else if (a.equals("--unique-query")) {
+                    uniqueQuery = true;
+                } else if (a.equals("--no-unique-query")) {
+                    uniqueQuery = false;
+                } else if (a.startsWith("--retain-open=")) {
+                    retainOpen = Integer.parseInt(a.substring("--retain-open=".length()));
+                } else if (a.equals("--retain-open") && i + 1 < args.length) {
+                    retainOpen = Integer.parseInt(args[++i]);
+                } else if (a.startsWith("--target-gb=")) {
+                    targetGb = Double.parseDouble(a.substring("--target-gb=".length()));
+                } else if (a.equals("--target-gb") && i + 1 < args.length) {
+                    targetGb = Double.parseDouble(args[++i]);
+                } else if (a.startsWith("--data-dir=")) {
+                    dataDir = new File(a.substring("--data-dir=".length()));
+                } else if (a.equals("--data-dir") && i + 1 < args.length) {
+                    dataDir = new File(args[++i]);
+                } else if (a.startsWith("--progress-file=")) {
+                    progressFile = new File(a.substring("--progress-file=".length()));
+                } else if (a.equals("--progress-file") && i + 1 < args.length) {
+                    progressFile = new File(args[++i]);
+                } else if (a.startsWith("--http-timing=")) {
+                    httpTimingFile = new File(a.substring("--http-timing=".length()));
+                } else if (a.equals("--http-timing") && i + 1 < args.length) {
+                    httpTimingFile = new File(args[++i]);
+                } else if (a.startsWith("--harvester-period=")) {
+                    harvesterPeriodMillis = parseDurationMillis(
+                            a.substring("--harvester-period=".length()));
+                } else if (a.equals("--harvester-period") && i + 1 < args.length) {
+                    harvesterPeriodMillis = parseDurationMillis(args[++i]);
+                } else if (a.startsWith("--ui-base=")) {
+                    uiBase = a.substring("--ui-base=".length());
+                } else if (a.equals("--ui-base") && i + 1 < args.length) {
+                    uiBase = args[++i];
+                } else if (a.equals("--help") || a.equals("-h")) {
+                    printHelpAndExit();
+                } else {
+                    throw new IllegalArgumentException("unknown arg: " + a);
+                }
+            }
+            if (mode == Mode.AGENT_CHURN && retainOpen == 0) {
+                retainOpen = 64;
+            }
+            if ((phase == Phase.DUAL || phase == Phase.QUERY_ONLY) && !durationSpecified) {
+                throw new IllegalArgumentException("--duration is required for --phase=" + phase.name()
+                        .toLowerCase().replace('_', '-'));
+            }
+            if (targetGb < 0) {
+                throw new IllegalArgumentException("--target-gb must not be negative");
+            }
+            if (dataDir == null) {
+                String dataDirProperty = System.getProperty("glowroot.data.dir");
+                dataDir = dataDirProperty == null || dataDirProperty.length() == 0
+                        ? new File("data")
+                        : new File(dataDirProperty);
+            }
+            if (progressFile == null) {
+                progressFile = new File(dataDir, "../fill-progress.json");
+            }
+            if (httpTimingFile == null) {
+                httpTimingFile = new File(dataDir, "../timing-http.csv");
+            }
+            if (uiBase == null) {
+                uiBase = "http://127.0.0.1:" + System.getProperty("glowroot.agent.port", "4000");
+            }
+            return new Options(mode, phase, durationMillis, threads, allocKb,
+                    uniqueQuery == null ? phase == Phase.FILL || phase == Phase.DUAL : uniqueQuery,
+                    retainOpen, targetGb, dataDir, progressFile, httpTimingFile, harvesterPeriodMillis,
+                    uiBase);
+        }
+
+        private static Mode parseMode(String value) {
+            if ("jdbc-stress".equals(value)) {
+                return Mode.JDBC_STRESS;
+            }
+            if ("agent-churn".equals(value)) {
+                return Mode.AGENT_CHURN;
+            }
+            throw new IllegalArgumentException("mode must be jdbc-stress|agent-churn: " + value);
+        }
+
+        private static Phase parsePhase(String value) {
+            if ("fill".equals(value)) {
+                return Phase.FILL;
+            }
+            if ("dual".equals(value)) {
+                return Phase.DUAL;
+            }
+            if ("query-only".equals(value)) {
+                return Phase.QUERY_ONLY;
+            }
+            throw new IllegalArgumentException("phase must be fill|dual|query-only: " + value);
+        }
+
+        private static long parseDurationMillis(String value) {
+            if (value.endsWith("ms")) {
+                return Long.parseLong(value.substring(0, value.length() - 2));
+            }
+            if (value.endsWith("s")) {
+                return Long.parseLong(value.substring(0, value.length() - 1)) * 1000L;
+            }
+            if (value.endsWith("m")) {
+                return Long.parseLong(value.substring(0, value.length() - 1)) * 60_000L;
+            }
+            return Long.parseLong(value);
+        }
+
+        private static void printHelpAndExit() {
+            System.out.println("Usage: StressMain --mode=jdbc-stress|agent-churn"
+                    + " [--duration=60s] [--threads=32] [--alloc-kb=512] [--retain-open=N]"
+                    + " [--unique-query|--no-unique-query]"
+                    + " [--phase=fill|dual|query-only] [--target-gb=60]"
+                    + " [--data-dir=PATH] [--progress-file=PATH] [--http-timing=PATH]"
+                    + " [--harvester-period=2s] [--ui-base=URL]");
+            System.exit(0);
+        }
+    }
+}

--- a/agent/stress/src/main/java/org/glowroot/agent/stress/Workloads.java
+++ b/agent/stress/src/main/java/org/glowroot/agent/stress/Workloads.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.stress;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.locks.LockSupport;
+
+final class Workloads {
+
+    private static final String JDBC_URL = "jdbc:hsqldb:mem:glowroot_stress";
+    // Pad length (chars) embedded in captured SQL so Glowroot's embedded H2 (compress=true)
+    // stores large full-query-text rows. Entropy per op matters: a static run of 'x' compresses
+    // away in data.mv.db. The mock DB below is HSQLDB in-memory — not that H2 file.
+    private static final int PAD_CHARS = 64 * 1024;
+
+    private final Connection bootstrap;
+    private final ThreadLocal<Connection> connections = new ThreadLocal<Connection>() {
+        @Override
+        protected Connection initialValue() {
+            try {
+                return DriverManager.getConnection(JDBC_URL, "sa", "");
+            } catch (SQLException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    };
+    private final ThreadLocal<char[]> padBuffers = new ThreadLocal<char[]>() {
+        @Override
+        protected char[] initialValue() {
+            return new char[PAD_CHARS];
+        }
+    };
+
+    Workloads() throws SQLException {
+        bootstrap = DriverManager.getConnection(JDBC_URL, "sa", "");
+        Statement statement = bootstrap.createStatement();
+        try {
+            statement.execute("create table stress_mock (id int, name varchar(100))");
+            for (int i = 0; i < 500; i++) {
+                statement.execute("insert into stress_mock (id, name) values (" + i + ", 'n" + i
+                        + "')");
+            }
+        } finally {
+            statement.close();
+        }
+    }
+
+    void close() throws SQLException {
+        bootstrap.close();
+    }
+
+    private static final String FIXED_SQL = "select id, name from stress_mock where id >= 0";
+
+    // woven via glowroot.plugin.json — steady dual load (no new full-query-text growth)
+    int jdbcOnce(int allocKb) throws SQLException {
+        byte[] pressure = allocKb <= 0 ? null : new byte[allocKb * 1024];
+        PreparedStatement select = connections.get().prepareStatement(FIXED_SQL);
+        int rows = 0;
+        try {
+            ResultSet rs = select.executeQuery();
+            try {
+                while (rs.next()) {
+                    rows++;
+                }
+            } finally {
+                rs.close();
+            }
+        } finally {
+            select.close();
+        }
+        return rows + (pressure == null ? 0 : pressure.length);
+    }
+
+    private String uniqueSqlPad(long uniqueSalt) {
+        char[] buf = padBuffers.get();
+        ThreadLocalRandom rnd = ThreadLocalRandom.current();
+        // Printable ASCII — high entropy so H2 page compression cannot collapse the LOB.
+        for (int i = 0; i < buf.length; i++) {
+            buf[i] = (char) (33 + rnd.nextInt(94));
+        }
+        return "pad-" + uniqueSalt + "-" + new String(buf);
+    }
+
+    private int runUniqueJdbc(int allocKb, long uniqueSalt) throws SQLException {
+        byte[] pressure = allocKb <= 0 ? null : new byte[allocKb * 1024];
+        String pad = uniqueSqlPad(uniqueSalt);
+        // Comment body carries cardinality; keep the executable SQL tiny for the in-memory mock DB.
+        String sql = "select id, name from stress_mock where id >= 0 /*" + pad + "*/";
+        PreparedStatement uniqueSelect = connections.get().prepareStatement(sql);
+        int rows = 0;
+        try {
+            ResultSet rs = uniqueSelect.executeQuery();
+            try {
+                while (rs.next()) {
+                    rows++;
+                }
+            } finally {
+                rs.close();
+            }
+        } finally {
+            uniqueSelect.close();
+        }
+        // Pace unique heavy pads so aggregate flush/H2 write can keep up (avoids OOM backlog).
+        LockSupport.parkNanos(2_000_000L);
+        return rows + (pressure == null ? 0 : pressure.length);
+    }
+
+    // woven via glowroot.plugin.json
+    int jdbcOnceUnique(int allocKb, long uniqueSalt) throws SQLException {
+        return runUniqueJdbc(allocKb, uniqueSalt);
+    }
+
+    // woven via glowroot.plugin.json
+    int jdbcOnceA(int allocKb, long uniqueSalt) throws SQLException {
+        return runUniqueJdbc(allocKb, uniqueSalt);
+    }
+
+    // woven via glowroot.plugin.json
+    int jdbcOnceB(int allocKb, long uniqueSalt) throws SQLException {
+        return runUniqueJdbc(allocKb, uniqueSalt);
+    }
+
+    // woven via glowroot.plugin.json
+    int jdbcOnceC(int allocKb, long uniqueSalt) throws SQLException {
+        return runUniqueJdbc(allocKb, uniqueSalt);
+    }
+
+    // woven via glowroot.plugin.json
+    int churnOnce(int allocKb) {
+        byte[] pressure = allocKb <= 0 ? null : new byte[allocKb * 1024];
+        return pressure == null ? 0 : pressure.length;
+    }
+
+    // woven via glowroot.plugin.json — holds an open transaction until release
+    static void retainOnce(CountDownLatch release, CountDownLatch started)
+            throws InterruptedException {
+        started.countDown();
+        release.await();
+    }
+}

--- a/agent/stress/src/main/resources/META-INF/glowroot.plugin.json
+++ b/agent/stress/src/main/resources/META-INF/glowroot.plugin.json
@@ -1,0 +1,72 @@
+{
+  "name": "Agent Stress Plugin",
+  "id": "glowroot-agent-stress",
+  "instrumentation": [
+    {
+      "className": "org.glowroot.agent.stress.Workloads",
+      "methodName": "jdbcOnce",
+      "methodParameterTypes": [ "int" ],
+      "captureKind": "transaction",
+      "transactionType": "Stress",
+      "transactionNameTemplate": "jdbc-stress",
+      "timerName": "jdbc stress"
+    },
+    {
+      "className": "org.glowroot.agent.stress.Workloads",
+      "methodName": "jdbcOnceUnique",
+      "methodParameterTypes": [ "int", "long" ],
+      "captureKind": "transaction",
+      "transactionType": "Stress",
+      "transactionNameTemplate": "jdbc-stress-unique",
+      "timerName": "jdbc stress unique"
+    },
+    {
+      "className": "org.glowroot.agent.stress.Workloads",
+      "methodName": "jdbcOnceA",
+      "methodParameterTypes": [ "int", "long" ],
+      "captureKind": "transaction",
+      "transactionType": "Stress",
+      "transactionNameTemplate": "fill-a",
+      "timerName": "jdbc stress"
+    },
+    {
+      "className": "org.glowroot.agent.stress.Workloads",
+      "methodName": "jdbcOnceB",
+      "methodParameterTypes": [ "int", "long" ],
+      "captureKind": "transaction",
+      "transactionType": "Stress",
+      "transactionNameTemplate": "fill-b",
+      "timerName": "jdbc stress"
+    },
+    {
+      "className": "org.glowroot.agent.stress.Workloads",
+      "methodName": "jdbcOnceC",
+      "methodParameterTypes": [ "int", "long" ],
+      "captureKind": "transaction",
+      "transactionType": "Stress",
+      "transactionNameTemplate": "fill-c",
+      "timerName": "jdbc stress"
+    },
+    {
+      "className": "org.glowroot.agent.stress.Workloads",
+      "methodName": "churnOnce",
+      "methodParameterTypes": [ "int" ],
+      "captureKind": "transaction",
+      "transactionType": "Stress",
+      "transactionNameTemplate": "agent-churn",
+      "timerName": "agent churn"
+    },
+    {
+      "className": "org.glowroot.agent.stress.Workloads",
+      "methodName": "retainOnce",
+      "methodParameterTypes": [
+        "java.util.concurrent.CountDownLatch",
+        "java.util.concurrent.CountDownLatch"
+      ],
+      "captureKind": "transaction",
+      "transactionType": "Stress",
+      "transactionNameTemplate": "agent-retain",
+      "timerName": "agent retain"
+    }
+  ]
+}

--- a/agent/stress/src/test/java/org/glowroot/agent/stress/CompareReportTest.java
+++ b/agent/stress/src/test/java/org/glowroot/agent/stress/CompareReportTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.stress;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public class CompareReportTest {
+
+    public static void main(String[] args) throws Exception {
+        shouldWriteComparisonForHttpAndH2Timings();
+    }
+
+    private static void shouldWriteComparisonForHttpAndH2Timings() throws Exception {
+        File root = Files.createTempDirectory("compare-report").toFile();
+        File a = new File(root, "a");
+        File b = new File(root, "b");
+        a.mkdirs();
+        b.mkdirs();
+        write(a, "fill-progress.json",
+                "{\"targetGb\":1,\"dataBytes\":1073741824,\"ops\":1000,\"updatedAt\":1000000}");
+        write(b, "fill-progress.json",
+                "{\"targetGb\":1,\"dataBytes\":2147483648,\"ops\":2000,\"updatedAt\":2000000}");
+        write(a, "timing-http.csv",
+                "ts,phase,endpoint,status,latencyMs\n"
+                        + "1,dual,/throughput,200,1\n"
+                        + "2,dual,/throughput,200,3\n"
+                        + "3,dual,/throughput,ERR,100\n");
+        write(b, "timing-http.csv",
+                "ts,phase,endpoint,status,latencyMs\n"
+                        + "1,dual,/throughput,200,2\n"
+                        + "2,dual,/throughput,200,4\n");
+        write(a, "timing-h2.csv", "ts,latencyMs,sqlTruncated\n1,12,select one\n");
+        write(b, "timing-h2.csv",
+                "ts,latencyMs,sqlTruncated\n1,50,select slow\n2,10,select fast\n");
+        File out = new File(root, "compare.md");
+
+        CompareReport.main(new String[] {
+                "--a=" + a.getPath(), "--b=" + b.getPath(), "--out=" + out.getPath()
+        });
+
+        String report = new String(Files.readAllBytes(out.toPath()), StandardCharsets.UTF_8);
+        assertContains(report, "## Fill");
+        assertContains(report, "## Dual HTTP");
+        assertContains(report, "| /throughput | 3.0 | 3.0 | 2 | 4.0 | 4.0 | 2 |");
+        assertContains(report, "## H2");
+        assertContains(report, "select slow");
+        assertContains(report, "## Events");
+    }
+
+    private static void write(File dir, String name, String contents) throws Exception {
+        Files.write(new File(dir, name).toPath(), contents.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void assertContains(String text, String expected) {
+        if (!text.contains(expected)) {
+            throw new AssertionError("expected report to contain: " + expected + "\n" + text);
+        }
+    }
+}

--- a/agent/stress/src/test/java/org/glowroot/agent/stress/QueryHarvesterTest.java
+++ b/agent/stress/src/test/java/org/glowroot/agent/stress/QueryHarvesterTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.agent.stress;
+
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+public class QueryHarvesterTest {
+
+    public static void main(String[] args) throws Exception {
+        shouldWriteRowsForSuccessfulEndpoints();
+        shouldSkipEndpointAfterFirst404();
+    }
+
+    private static void shouldWriteRowsForSuccessfulEndpoints() throws Exception {
+        List<String> requests = new ArrayList<String>();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", new TestHandler(requests, false));
+        server.start();
+        try {
+            File timingFile = Files.createTempDirectory("query-harvester").resolve("timing-http.csv")
+                    .toFile();
+            QueryHarvester harvester = new QueryHarvester(
+                    "http://127.0.0.1:" + server.getAddress().getPort(), 1000, timingFile, "dual");
+
+            harvester.harvestOnce();
+
+            assertEquals(7, requests.size(), "request count");
+            assertTrue(requests.contains("/backend/transaction/throughput"), "throughput requested");
+            assertTrue(requests.contains("/backend/transaction/summaries"), "summaries requested");
+            assertTrue(requests.contains("/backend/trace/header"), "trace header requested");
+            List<String> lines = Files.readAllLines(timingFile.toPath(), StandardCharsets.UTF_8);
+            assertEquals(8, lines.size(), "CSV header plus response rows");
+            assertTrue(lines.get(0).equals("ts,phase,endpoint,status,latencyMs"), "CSV header");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private static void shouldSkipEndpointAfterFirst404() throws Exception {
+        List<String> requests = new ArrayList<String>();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", new TestHandler(requests, true));
+        server.start();
+        try {
+            File timingFile = Files.createTempDirectory("query-harvester").resolve("timing-http.csv")
+                    .toFile();
+            QueryHarvester harvester = new QueryHarvester(
+                    "http://127.0.0.1:" + server.getAddress().getPort(), 1000, timingFile, "dual");
+
+            harvester.harvestOnce();
+            harvester.harvestOnce();
+
+            assertEquals(1, count(requests, "/backend/jvm/environment"),
+                    "404 endpoint should only be requested once");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private static class TestHandler implements HttpHandler {
+        private final List<String> requests;
+        private final boolean environmentMissing;
+
+        private TestHandler(List<String> requests, boolean environmentMissing) {
+            this.requests = requests;
+            this.environmentMissing = environmentMissing;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws java.io.IOException {
+            String path = exchange.getRequestURI().getPath();
+            requests.add(path);
+            if (environmentMissing && "/backend/jvm/environment".equals(path)) {
+                exchange.sendResponseHeaders(404, -1);
+                exchange.close();
+                return;
+            }
+            String body = "/backend/transaction/points".equals(path)
+                    ? "{\"normalPoints\":[[1,2,\"\",\"trace-1\"]]}"
+                    : "{}";
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.close();
+        }
+    }
+
+    private static int count(List<String> values, String value) {
+        int count = 0;
+        for (String candidate : values) {
+            if (value.equals(candidate)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static void assertEquals(int expected, int actual, String description) {
+        if (expected != actual) {
+            throw new AssertionError(description + ": expected " + expected + ", got " + actual);
+        }
+    }
+
+    private static void assertTrue(boolean condition, String description) {
+        if (!condition) {
+            throw new AssertionError(description);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <module>agent/plugins/spring-plugin</module>
     <module>agent/plugins/struts-plugin</module>
     <module>agent/benchmarks</module>
+    <module>agent/stress</module>
     <module>agent/ui-sandbox</module>
     <module>agent/dist-maven-plugin</module>
     <module>agent/dist</module>


### PR DESCRIPTION
Embedded H2 at tens of GB is where Glowroot hurts (#755, #1180-ish). This PR is lab tooling + index/SQL fixes — **not** a second JDBC pool (that’s deferred).

## 1. `agent/stress` module (not in agent dist)

Operator tool, `stress.jar`:
- **fill** — grow `data.mv.db` toward `--target-gb` (pads in SQL comments, paced)
- **dual** — JDBC load + HTTP harvester hitting UI APIs, CSV timings
- JMH benches for queue/JDBC pressure while I was debugging

Run locally on throwaway dirs only.

## 2. Schema / query changes (shipped in agent)

| Change | Why |
|--------|-----|
| UNIQUE indexes in `Schemas` | `full_text_sha1`, sync support |
| `TraceDao` covering indexes | error-message trace paths |
| `AggregateDao` indexes incl. `*_capped_id` | `/queries` CappedId path |
| `TracePointQueryBuilder` stable ORDER BY | planner stops thrashing |
| `-Dglowroot.internal.h2.timingLog` | opt-in H2 timing (off default) |

**Existing big DB:** first boot after upgrade runs schema sync → **new indexes rebuild can take hours** on ~60 GB. Plan a maintenance window.

## 3. Numbers I have (pre-index on ~60.3 GB store, 30 min dual)

- Workload ~17k ops/s, 0 errors
- HTTP ~97% 200; worst `/backend/transaction/summaries` ~1.5s max
- Some 30s harvester timeouts under lock contention — single `DataSource` connection unchanged

Re-measure **after** index sync is the next step; this PR is the code + harness.

## Out of scope

- Hikari read/write split for embedded
- Central / Cassandra
- Checking in datasets or `.superpowers/` junk

## Tests

- [x] `SchemasTest`, stress module tests, package smoke fill `--target-gb=1`
- [ ] Maintainer: dual run on a large dir after index sync
- [x] Small/empty store still boots