### PR TITLE
[FEATURE] Default H2 AUTO_COMPACT_FILL_RATE to 30 for #1180 MVStore CPU

### DIFF
--- a/agent/embedded/src/main/java/org/glowroot/agent/embedded/util/DataSource.java
+++ b/agent/embedded/src/main/java/org/glowroot/agent/embedded/util/DataSource.java
@@ -63,6 +63,14 @@ public class DataSource {
     private static final int QUERY_TIMEOUT_SECONDS =
             Integer.getInteger("glowroot.internal.h2.queryTimeout", 60);
 
+    // H2 2.x MVStore only. Glowroot default 30 (H2 stock default is 90) to cut background
+    // rewriteChunks CPU/IO on shared-JVM embeds (#1180). Override with
+    // -Dglowroot.internal.h2.autoCompactFillRate=N (90 = stock H2; 0 = disable auto-compact).
+    // WRITE_DELAY is PageStore-era; Hikari/multi-connection pool still deferred.
+    private static final int DEFAULT_AUTO_COMPACT_FILL_RATE = 30;
+    private static final int AUTO_COMPACT_FILL_RATE =
+            resolveAutoCompactFillRate(Integer.getInteger("glowroot.internal.h2.autoCompactFillRate"));
+
     // null means use memDb
     private final @Nullable File dbFile;
     private final Thread shutdownHookThread;
@@ -655,11 +663,25 @@ public class DataSource {
             props.setProperty("user", "sa");
             props.setProperty("password", "");
             // db_close_on_exit=false since jvm shutdown hook is handled by DataSource
-            String url = "jdbc:h2:" + dbPath
-                    + ";compress=true;db_close_on_exit=false;cache_size=" + cacheSizeKb
-                    + ";NON_KEYWORDS=USER,VALUE";
-            return DriverManager.getConnection(url, props);
+            return DriverManager.getConnection(
+                    buildFileUrl(dbPath, cacheSizeKb, AUTO_COMPACT_FILL_RATE), props);
         }
+    }
+
+    /**
+     * File-backed H2 JDBC URL. Always sets {@code AUTO_COMPACT_FILL_RATE} (Glowroot default 30).
+     */
+    @VisibleForTesting
+    static String buildFileUrl(String dbPath, int cacheSizeKb, int autoCompactFillRate) {
+        return "jdbc:h2:" + dbPath
+                + ";compress=true;db_close_on_exit=false;cache_size=" + cacheSizeKb
+                + ";NON_KEYWORDS=USER,VALUE"
+                + ";AUTO_COMPACT_FILL_RATE=" + autoCompactFillRate;
+    }
+
+    @VisibleForTesting
+    static int resolveAutoCompactFillRate(@Nullable Integer override) {
+        return override != null ? override : DEFAULT_AUTO_COMPACT_FILL_RATE;
     }
 
     private static <T> T extractAndClose(ResultSet resultSet, ResultSetExtractor<T> rse)

--- a/agent/embedded/src/test/java/org/glowroot/agent/embedded/util/DataSourceTest.java
+++ b/agent/embedded/src/test/java/org/glowroot/agent/embedded/util/DataSourceTest.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -27,6 +28,24 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class DataSourceTest {
+
+    @Test
+    public void resolveAutoCompactFillRateDefaultsTo30() {
+        assertThat(DataSource.resolveAutoCompactFillRate(null)).isEqualTo(30);
+    }
+
+    @Test
+    public void resolveAutoCompactFillRateHonorsOverride() {
+        assertThat(DataSource.resolveAutoCompactFillRate(90)).isEqualTo(90);
+        assertThat(DataSource.resolveAutoCompactFillRate(0)).isEqualTo(0);
+    }
+
+    @Test
+    public void buildFileUrlAlwaysSetsAutoCompactFillRate() {
+        assertThat(DataSource.buildFileUrl("/tmp/data", 131072, 30))
+                .contains("cache_size=131072")
+                .endsWith(";AUTO_COMPACT_FILL_RATE=30");
+    }
 
     @Test
     public void testDebugNoArgs() throws SQLException {


### PR DESCRIPTION
## Summary
- Embedded H2 JDBC URL always sets `AUTO_COMPACT_FILL_RATE` with **Glowroot default 30** (H2 stock default is 90). Cuts background `rewriteChunks` CPU/IO on shared-JVM embeds (#1180).
- Override: `-Dglowroot.internal.h2.autoCompactFillRate=N` — use `90` for stock H2 reclaim behavior, `0` to disable auto-compact (then Admin → Compact / `shutdown compact`).
- **Not** `WRITE_DELAY` (PageStore-era). **Hikari / pool still deferred** (single `DataSource`).

## Test plan
- [x] `mvn test -Dtest=DataSourceTest -pl :glowroot-agent-embedded-unshaded -am -Dglowroot.ui.skip -Dsurefire.failIfNoSpecifiedTests=false`
- [ ] Compare MVStore background-writer CPU before/after on a large `data.mv.db` (default 30 vs `-D…=90`)