### PR TITLE
[UI-ENRICH] Link Allocated memory thread stats to docs (#630)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Central needs its own install — see [Agent Installation (for Central Collector
 | Plugins / custom Instrumentation | [Plugins](https://github.com/glowroot/glowroot/wiki/Plugins) · [Instrumentation](https://github.com/glowroot/glowroot/wiki/Instrumentation) |
 | Empty Queries / Service Calls / Web? | [Plugin coverage gaps](https://github.com/glowroot/glowroot/wiki/Plugin-coverage-gaps) · [What Glowroot does not do](https://github.com/glowroot/glowroot/wiki/What-Glowroot-does-not-do) |
 | UI orientation (tabs, alerts, gauges, …) | [Transaction tabs](https://github.com/glowroot/glowroot/wiki/Transaction-tabs) · [wiki UI / configuration](https://github.com/glowroot/glowroot/wiki#ui--configuration) |
+| JVM thread “Allocated memory” meaning | [docs/jvm-thread-stats-allocated-memory.md](docs/jvm-thread-stats-allocated-memory.md) (wiki paste: [JVM-thread-stats-allocated-memory](https://github.com/glowroot/glowroot/wiki/JVM-thread-stats-allocated-memory)) · [#630](https://github.com/glowroot/glowroot/issues/630) |
 | Contributing (modules / engine map) | [For contributors](https://github.com/glowroot/glowroot/wiki/For-contributors) · [Plugin and Pointcut basics](https://github.com/glowroot/glowroot/wiki/Plugin-and-Pointcut-basics) |
 | Community Q&A | [GitHub Discussions](https://github.com/glowroot/glowroot/discussions) |
 | AI assistant (`glowroot-ops`) | [skills/glowroot-ops/](skills/glowroot-ops/) |

--- a/docs/jvm-thread-stats-allocated-memory.md
+++ b/docs/jvm-thread-stats-allocated-memory.md
@@ -1,0 +1,44 @@
+# JVM thread stats — Allocated memory
+
+> **Wiki paste target:** publish this page as
+> [`JVM-thread-stats-allocated-memory`](https://github.com/glowroot/glowroot/wiki/JVM-thread-stats-allocated-memory)
+> (same title / slug). Tracks [#630](https://github.com/glowroot/glowroot/issues/630).
+
+## What the number is
+
+**Allocated memory** on transaction / trace JVM thread stats is the **cumulative** number of bytes that thread allocated while the transaction (or live trace) was running.
+
+It is **not**:
+
+- how much heap the JVM is “holding” right now
+- a high-water mark of live heap for that thread
+- RSS / process memory
+
+Bytes that were allocated and later garbage-collected still count. That is why the figure can look huge compared to `-Xmx` or the app’s heap size (reporters have seen multi‑GB or even TB-scale values on long or allocation-heavy work).
+
+## How Glowroot calculates it
+
+1. Capture must be on: **Configuration → Transaction → Capture JVM thread stats**.
+2. At transaction start (on that thread), Glowroot records
+   `com.sun.management.ThreadMXBean.getThreadAllocatedBytes(threadId)` (when the JVM supports it).
+3. At completion (or when reading a still-running trace), it records the same counter again.
+4. The displayed value is the **delta**: `end − start` for that thread.
+
+Main-thread and auxiliary-thread stats are tracked separately when aux work is attributed to the transaction.
+
+On **aggregate** transaction views (e.g. Average), the UI shows an **average per transaction**:
+`totalAllocatedBytes / transactionCount` (same pattern as CPU / blocked / waited times).
+
+If the JVM does not support allocated-memory tracking, or capture is off, the row is omitted (`-1` / unavailable).
+
+## How to use it
+
+- High allocated memory on a transaction name → that path creates a lot of short-lived (or retained) objects; pair with **Profile** / heap tools if you need *what* allocates.
+- Compare transactions relative to each other; do not treat the number as “RAM in use.”
+- For a single slow request, open the **trace**: the value is measured from the start of that trace.
+
+## See also
+
+- [[Transaction configuration]] — enable thread stats
+- [[Transaction tabs]] — Average and related views
+- Issue [#630](https://github.com/glowroot/glowroot/issues/630)

--- a/ui/app/template/gt-thread-stats.html
+++ b/ui/app/template/gt-thread-stats.html
@@ -10,5 +10,9 @@
   </div>
   <div ng-if="threadStats.totalAllocatedBytes != -1">
     Allocated memory: {{threadStats.totalAllocatedBytes / transactionCount | gtBytes}}
+    <a href="https://github.com/glowroot/glowroot/blob/main/docs/jvm-thread-stats-allocated-memory.md"
+       target="_blank"
+       rel="noopener noreferrer"
+       title="What allocated memory means (cumulative)">what is this?</a>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Adds `docs/jvm-thread-stats-allocated-memory.md`: Allocated memory is a **cumulative** `ThreadMXBean.getThreadAllocatedBytes` delta for the txn thread (not heap residency / high-water mark).
- Transaction thread-stats UI gets a `what is this?` link to that doc.
- README Documentation table points at the doc (and the intended wiki slug).

**Wiki:** Never-lab cannot push `glowroot.wiki`. After merge, please paste the doc body as wiki page `JVM-thread-stats-allocated-memory`; the UI link can then switch to the wiki URL if you prefer.

Closes #630

## Test plan
- [ ] Open Average (or a trace) with JVM thread stats on — Allocated memory row shows `what is this?`
- [ ] Link opens the markdown and the cumulative vs heap explanation is clear
- [ ] (Maintainer) Paste wiki page from the doc

