### PR TITLE
Default H2 cache to Fixed 32 MB; document /health vs /readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Central needs its own install — see [Agent Installation (for Central Collector
 | Central on Docker | [Central Collector with Docker](https://github.com/glowroot/glowroot/wiki/Central-Collector-with-Docker) |
 | Troubleshooting | [Troubleshooting Tips](https://github.com/glowroot/glowroot/wiki/Troubleshooting-Tips) |
 | Storage (H2 / Cassandra TTL) | [Administration-Storage](https://github.com/glowroot/glowroot/wiki/Administration-Storage) |
+| HTTP `/health` vs `/readiness` (0.14.8+) | [docs/health-endpoints.md](docs/health-endpoints.md) · [0.14.8 upgrade notes](docs/0.14.8-upgrade-notes.md) |
 | Plugins / custom Instrumentation | [Plugins](https://github.com/glowroot/glowroot/wiki/Plugins) · [Instrumentation](https://github.com/glowroot/glowroot/wiki/Instrumentation) |
 | Empty Queries / Service Calls / Web? | [Plugin coverage gaps](https://github.com/glowroot/glowroot/wiki/Plugin-coverage-gaps) · [What Glowroot does not do](https://github.com/glowroot/glowroot/wiki/What-Glowroot-does-not-do) |
 | UI orientation (tabs, alerts, gauges, …) | [Transaction tabs](https://github.com/glowroot/glowroot/wiki/Transaction-tabs) · [wiki UI / configuration](https://github.com/glowroot/glowroot/wiki#ui--configuration) |

--- a/agent/embedded/src/main/java/org/glowroot/agent/embedded/util/DataSource.java
+++ b/agent/embedded/src/main/java/org/glowroot/agent/embedded/util/DataSource.java
@@ -643,7 +643,7 @@ public class DataSource {
     }
 
     private static int resolveInitialCacheSizeKb() {
-        return H2CacheSize.resolveKb(H2CacheSize.MODE_AUTO, H2CacheSize.AUTO_MB,
+        return H2CacheSize.resolveKb(H2CacheSize.MODE_FIXED, H2CacheSize.DEFAULT_MB,
                 Runtime.getRuntime().maxMemory(), System.getProperty(H2CacheSize.SYSTEM_PROPERTY));
     }
 

--- a/common2/src/main/java/org/glowroot/common2/config/EmbeddedStorageConfig.java
+++ b/common2/src/main/java/org/glowroot/common2/config/EmbeddedStorageConfig.java
@@ -79,13 +79,14 @@ public abstract class EmbeddedStorageConfig implements StorageConfig {
     }
 
     /**
-     * H2 cache sizing for embedded: {@code auto} (128 MB target), {@code fixed} (MB in
-     * {@link #h2CacheValue()}), or {@code percent} (% of -Xmx in {@link #h2CacheValue()}).
-     * Effective size is clamped; see {@link H2CacheSize}.
+     * H2 cache sizing for embedded: {@code fixed} (MB in {@link #h2CacheValue()}),
+     * {@code auto} (128 MB target), or {@code percent} (% of -Xmx in {@link #h2CacheValue()}).
+     * Effective size is clamped; see {@link H2CacheSize}. Default is fixed
+     * {@link H2CacheSize#DEFAULT_MB} MB.
      */
     @Value.Default
     public String h2CacheMode() {
-        return H2CacheSize.MODE_AUTO;
+        return H2CacheSize.MODE_FIXED;
     }
 
     /**
@@ -94,7 +95,7 @@ public abstract class EmbeddedStorageConfig implements StorageConfig {
      */
     @Value.Default
     public int h2CacheValue() {
-        return H2CacheSize.AUTO_MB;
+        return H2CacheSize.DEFAULT_MB;
     }
 
     @Value.Derived

--- a/common2/src/main/java/org/glowroot/common2/config/H2CacheSize.java
+++ b/common2/src/main/java/org/glowroot/common2/config/H2CacheSize.java
@@ -18,8 +18,9 @@ package org.glowroot.common2.config;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Resolves H2 {@code cache_size} (KB) for embedded installs. Auto targets 128 MB; values are
- * clamped to {@code [16 MB, min(5% of max heap, 256 MB)]} so shared-JVM deploys stay safe.
+ * Resolves H2 {@code cache_size} (KB) for embedded installs. Default UI mode is fixed
+ * {@link #DEFAULT_MB} MB; auto targets {@link #AUTO_MB} MB. Values are clamped to
+ * {@code [16 MB, min(5% of max heap, 256 MB)]} so shared-JVM deploys stay safe.
  */
 public final class H2CacheSize {
 
@@ -29,6 +30,8 @@ public final class H2CacheSize {
 
     public static final String SYSTEM_PROPERTY = "glowroot.internal.h2.cacheSize";
 
+    /** Default for new installs ({@link #MODE_FIXED}). Between the historical ~8 MB and auto 128 MB. */
+    public static final int DEFAULT_MB = 32;
     public static final int AUTO_MB = 128;
     public static final int FLOOR_MB = 16;
     public static final int CEILING_MB = 256;

--- a/common2/src/test/java/org/glowroot/common2/config/H2CacheSizeTest.java
+++ b/common2/src/test/java/org/glowroot/common2/config/H2CacheSizeTest.java
@@ -32,6 +32,14 @@ public class H2CacheSizeTest {
     }
 
     @Test
+    public void defaultFixedIs32Mb() {
+        int kb = H2CacheSize.resolveKb(H2CacheSize.MODE_FIXED, H2CacheSize.DEFAULT_MB, XMX_10G,
+                null);
+        assertThat(kb).isEqualTo(32 * 1024);
+        assertThat(H2CacheSize.DEFAULT_MB).isEqualTo(32);
+    }
+
+    @Test
     public void fixedClampedToFivePercentAndCeiling() {
         // request 1024 MB on 10g: 5%=512, ceiling=256 → 256
         int kb = H2CacheSize.resolveKb(H2CacheSize.MODE_FIXED, 1024, XMX_10G, null);

--- a/docs/0.14.8-upgrade-notes.md
+++ b/docs/0.14.8-upgrade-notes.md
@@ -1,0 +1,19 @@
+# 0.14.8 upgrade notes (draft for GitHub Release)
+
+Paste or adapt into the 0.14.8 GitHub Release body.
+
+## Breaking / ops
+
+### `/health` is liveness, not readiness
+
+**0.14.7:** `GET /health` checked storage (Cassandra on Central, H2 on embedded).
+
+**0.14.8:** `GET /health` (and `/liveness`, `/healthz`) only confirm the UI process is up. Storage readiness is **`/readiness`** or **`/ready`**.
+
+Update Kubernetes/Docker/LB probes before or when upgrading. Details: [docs/health-endpoints.md](health-endpoints.md).
+
+## Embedded defaults
+
+### H2 page cache default is Fixed 32 MB
+
+Early 0.14.8 betas defaulted H2 cache mode to **Auto** (~128 MB target). New installs now default to **Fixed 32 MB** (still clamped to 16–256 MB and ≤5% of `-Xmx`). Existing saved Storage config is unchanged. Raise via Administration → Storage or `-Dglowroot.internal.h2.cacheSize=<KB>`.

--- a/docs/health-endpoints.md
+++ b/docs/health-endpoints.md
@@ -1,0 +1,30 @@
+# HTTP health endpoints (UI / Central)
+
+Applies to the Glowroot HTTP UI port (embedded agent UI and glowroot-central).
+
+## Endpoints (0.14.8+)
+
+| Path | Role | Behavior |
+|------|------|----------|
+| `/liveness`, `/healthz`, **`/health`** | **Liveness** | Always `200` + `Glowroot OK` if the HTTP process is up. Does **not** check Cassandra (Central) or H2. |
+| `/readiness`, `/ready` | **Readiness** | Runs storage health (`RepoAdmin.runHealthCheck()`). Central: Cassandra probe. Embedded: H2. Failure → `503` + plain-text error. |
+
+## Breaking change vs 0.14.7
+
+On **0.14.7**, **`GET /health` was readiness** (storage check).
+
+From **0.14.8**, **`GET /health` is liveness** (same as `/liveness` / `/healthz`).
+
+If Kubernetes, Docker `HEALTHCHECK`, load balancers, or [Healthchecks.io](https://healthchecks.io)-style pingers still call `/health` expecting Cassandra/H2 readiness, switch them to **`/readiness`** or **`/ready`** before upgrading. Leaving `/health` unchanged will keep routing traffic to a Central whose Cassandra is down.
+
+## Examples
+
+```bash
+# process up?
+curl -sf http://127.0.0.1:4000/liveness
+
+# storage ready? (use this for k8s readinessProbe / LB backend health)
+curl -sf http://127.0.0.1:4000/readiness
+```
+
+Central Docker Compose / k8s: prefer `readinessProbe` → `/readiness` and `livenessProbe` → `/liveness` (or `/healthz`).

--- a/ui/app/scripts/controllers/admin/storage.js
+++ b/ui/app/scripts/controllers/admin/storage.js
@@ -163,10 +163,10 @@ glowroot.controller('AdminStorageCtrl', [
       if (!$scope.layout.central) {
         $scope.page.fullQueryTextExpirationDays = data.fullQueryTextExpirationHours / 24;
         if (!data.h2CacheMode) {
-          data.h2CacheMode = 'auto';
+          data.h2CacheMode = 'fixed';
         }
         if (data.h2CacheValue === undefined || data.h2CacheValue === null) {
-          data.h2CacheValue = 128;
+          data.h2CacheValue = 32;
         }
         refreshH2CacheWarning();
       }

--- a/ui/app/template/help/storage-h2-cache.html
+++ b/ui/app/template/help/storage-h2-cache.html
@@ -1,6 +1,7 @@
 <div class="gt-storage-help">
   <div><strong>H2 cache</strong> — in-memory page cache for H2 (same JVM heap as the app), not disk storage.</div>
   <ul>
+    <li><strong>Default</strong> — Fixed <strong>32 MB</strong> on new installs (was Auto 128 MB target in early 0.14.8 betas).</li>
     <li><strong>Auto</strong> — targets 128 MB.</li>
     <li><strong>Fixed MB</strong> / <strong>% of -Xmx</strong> — your target before clamping.</li>
     <li><strong>Clamp</strong> — effective size is always between 16 and 256 MB, and at most 5% of <code>-Xmx</code>.</li>

--- a/ui/src/main/java/org/glowroot/ui/UiModule.java
+++ b/ui/src/main/java/org/glowroot/ui/UiModule.java
@@ -212,6 +212,8 @@ public class UiModule {
         httpServices.put(Pattern.compile("^/backend/trace/aux-thread-profile$"),
                 traceDetailHttpService);
         httpServices.put(Pattern.compile("^/log$"), glowrootLogHttpService);
+        // Liveness: process up. Readiness (Cassandra/H2): /readiness and /ready.
+        // Breaking vs 0.14.7: /health used to be readiness — see docs/health-endpoints.md
         httpServices.put(Pattern.compile("^/health$"), livenessHttpService);
         httpServices.put(Pattern.compile("^/liveness$"), livenessHttpService);
         httpServices.put(Pattern.compile("^/healthz$"), livenessHttpService);


### PR DESCRIPTION
## Summary
- New embedded installs default H2 page cache to **Fixed 32 MB** (early 0.14.8 betas used Auto ~128 MB). Auto stays in the Storage UI. Existing saved config unchanged.
- Document the 0.14.8 probe change: `/health` is **liveness**; use `/readiness` or `/ready` for Cassandra/H2. See `docs/health-endpoints.md` and `docs/0.14.8-upgrade-notes.md` (for the release body).

## Test plan
- [x] `mvn test -Dtest=H2CacheSizeTest -pl :glowroot-common2`
- [x] Fresh embedded sandbox: Administration → Storage shows Fixed / 32 MB effective (no sysprop override)
- [ ] Confirm Auto still selectable and targets 128 MB (clamped)
- [x] Curl `/health` vs `/readiness` on Central with Cassandra stopped
