### PR TITLE
[BUGFIX] Complete child agent rollup pagination so group aggregates can run (#1090)

### DIFF
--- a/central/src/main/java/org/glowroot/central/repo/ActiveAgentDao.java
+++ b/central/src/main/java/org/glowroot/central/repo/ActiveAgentDao.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.Row;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -259,24 +260,15 @@ public class ActiveAgentDao implements ActiveAgentRepository {
                 .setInstant(2, Instant.ofEpochMilli(revisedTo));
 
         List<String> agentIds = new ArrayList<>();
-        Function<AsyncResultSet, CompletableFuture<List<String>>> compute = new Function<AsyncResultSet, CompletableFuture<List<String>>>() {
-            @Override
-            public CompletableFuture<List<String>> apply(AsyncResultSet results) {
-                for (Row row : results.currentPage()) {
-                    String agentId = topLevelId + checkNotNull(row.getString(0));
-                    agentIds.add(agentId);
-                }
-                if (results.hasMorePages()) {
-                    results.fetchNextPage().thenCompose(this::apply).toCompletableFuture();
-                }
-                return CompletableFuture.completedFuture(agentIds);
-            }
-        };
         Set<String> allAgentRollupIds = new HashSet<>();
         Set<String> directChildAgentRollupIds = new HashSet<>();
         Multimap<String, String> childMultimap = HashMultimap.create();
         Map<String, CompletableFuture<String>> agentDisplayFutureMap = new HashMap<>();
-        return session.readAsync(boundStatement, profile).thenCompose(compute).thenRun(() -> {
+        // must return the next-page future (same as readActiveTopLevelAgentRollups above);
+        // otherwise RollupService walks an incomplete agent tree and parent aggregate rollups stall
+        return session.readAsync(boundStatement, profile)
+                .thenCompose(results -> accumulateChildAgentIds(results, topLevelId, agentIds))
+                .thenRun(() -> {
             for (String agentId : agentIds) {
                 List<String> agentRollupIds = AgentRollupIds.getAgentRollupIds(agentId);
                 allAgentRollupIds.addAll(agentRollupIds);
@@ -315,6 +307,20 @@ public class ActiveAgentDao implements ActiveAgentRepository {
             agentRollups.sort(Comparator.comparing(AgentRollup::display));
             return agentRollups;
         });
+    }
+
+    @VisibleForTesting
+    static CompletableFuture<List<String>> accumulateChildAgentIds(AsyncResultSet results,
+            String topLevelId, List<String> agentIds) {
+        for (Row row : results.currentPage()) {
+            agentIds.add(topLevelId + checkNotNull(row.getString(0)));
+        }
+        if (results.hasMorePages()) {
+            return results.fetchNextPage()
+                    .thenCompose(next -> accumulateChildAgentIds(next, topLevelId, agentIds))
+                    .toCompletableFuture();
+        }
+        return CompletableFuture.completedFuture(agentIds);
     }
 
     private static AgentRollup createAgentRollup(String agentRollupId,

--- a/central/src/test/java/org/glowroot/central/repo/ActiveAgentDaoTest.java
+++ b/central/src/test/java/org/glowroot/central/repo/ActiveAgentDaoTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glowroot.central.repo;
+
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ActiveAgentDaoTest {
+
+    @Test
+    public void shouldAccumulateChildAgentIdsAcrossPages() throws Exception {
+        Row page1Row = mock(Row.class);
+        when(page1Row.getString(0)).thenReturn("Jboss::node1");
+        Row page2Row = mock(Row.class);
+        when(page2Row.getString(0)).thenReturn("Jboss::node2");
+
+        AsyncResultSet page2 = mock(AsyncResultSet.class);
+        when(page2.currentPage()).thenReturn(List.of(page2Row));
+        when(page2.hasMorePages()).thenReturn(false);
+
+        AsyncResultSet page1 = mock(AsyncResultSet.class);
+        when(page1.currentPage()).thenReturn(List.of(page1Row));
+        when(page1.hasMorePages()).thenReturn(true);
+        CompletionStage<AsyncResultSet> nextPage = CompletableFuture.completedFuture(page2);
+        when(page1.fetchNextPage()).thenReturn(nextPage);
+
+        List<String> agentIds = new ArrayList<>();
+        List<String> result = ActiveAgentDao.accumulateChildAgentIds(page1, "Prod::", agentIds)
+                .get();
+
+        assertThat(result).containsExactly("Prod::Jboss::node1", "Prod::Jboss::node2");
+        assertThat(agentIds).isSameAs(result);
+    }
+
+    @Test
+    public void shouldAccumulateChildAgentIdsFromSinglePage() throws Exception {
+        Row row = mock(Row.class);
+        when(row.getString(0)).thenReturn("alone");
+
+        AsyncResultSet page = mock(AsyncResultSet.class);
+        when(page.currentPage()).thenReturn(List.of(row));
+        when(page.hasMorePages()).thenReturn(false);
+
+        List<String> result = ActiveAgentDao.accumulateChildAgentIds(page, "Env::", new ArrayList<>())
+                .get();
+
+        assertThat(result).containsExactly("Env::alone");
+    }
+}


### PR DESCRIPTION
## Summary
- `ActiveAgentDao.readActiveChildAgentRollups` fired Cassandra `fetchNextPage()` without returning the future (unlike top-level reads and every other paging site in Central). With enough `active_child_rollup_*` rows to page, `RollupService` walked an incomplete agent tree and never called `aggregateDao.rollup` for missing mid-level groups — leaf agent charts stayed fine, group/rollup charts stayed empty (#1090).
- Chain next pages the same way as `readActiveTopLevelAgentRollups`, with a small unit test covering multi-page accumulation.

## Test plan
- [x] `mvn test -Dtest=ActiveAgentDaoTest -pl :glowroot-central -Dglowroot.ui.skip`
- [ ] On a Central with nested agent ids (`Env::Group::host`) and enough child active rows to exceed the driver page size (or force a small page size in a lab), confirm group Transaction charts fill after upgrade
- [ ] Re-check a previously empty group on 0.14.x after this Central build has run rollups for a few minutes
